### PR TITLE
Setup docs for Codex agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Codex Agent Configuration
+
+run: |
+  swiftlint
+  xcodebuild -scheme AirFit -destination 'platform=iOS Simulator,name=iPhone 15' test
+
+## Documentation
+
+- Consult `Docs/Agents.md` for coding style and module instructions.
+- Architecture plans live under `Docs/`. Use these docs to guide implementation.
+
+## General Guidance
+
+- Ensure commits are descriptive and keep the working tree clean.
+- Tests and lint must pass before proposing a PR.

--- a/AirFit/Docs/Agents.md
+++ b/AirFit/Docs/Agents.md
@@ -1,6 +1,8 @@
 # AirFit Agent Guidelines
 
 This repository documents AirFit. All code generation and docs must follow these guidelines.
+See `../../AGENTS.md` for build and test commands used by Codex agents.
+
 
 ## 1. Source of Truth
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# AirFit
+
+AirFit is a SwiftUI fitness companion for iOS and watchOS. The repository is organized for OpenAI Codex agents and human contributors alike.
+
+## Key Directories
+
+- `AirFit/` – Xcode project, source, and tests
+- `AirFit/Docs/` – architecture plans and module specifications
+
+## Building & Testing
+
+Run SwiftLint and the Xcode build from the repository root:
+
+```bash
+swiftlint
+xcodebuild -scheme AirFit -destination 'platform=iOS Simulator,name=iPhone 15' test
+```
+
+## Documentation
+
+See the `Docs/` directory for detailed design and module breakdowns. The main entry points are:
+
+- `Docs/Design.md` – visual and UX guidelines
+- `Docs/ArchitectureOverview.md` – overall app architecture
+- `Docs/Agents.md` – coding conventions and module instructions
+
+The `AGENTS.md` file in the repository root contains build and test commands for Codex agents.


### PR DESCRIPTION
## Summary
- create repo-level `AGENTS.md` with build/test commands
- add a high level README
- reference the new file from `Docs/Agents.md`

## Testing
- `swiftlint` *(fails: command not found)*
- `xcodebuild -scheme AirFit -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*