### PR TITLE
Implement service protocols and test mocks

### DIFF
--- a/AirFit/AirFitTests/Mocks/MockAIService.swift
+++ b/AirFit/AirFitTests/Mocks/MockAIService.swift
@@ -1,0 +1,33 @@
+@testable import AirFit
+import Foundation
+
+@MainActor
+final class MockAIService: AIServiceProtocol, MockProtocol {
+    var invocations: [String: [Any]] = [:]
+    var stubbedResults: [String: Any] = [:]
+
+    var analyzeGoalResult: Result<StructuredGoal, Error> = .failure(MockError.notSet)
+    private(set) var analyzeGoalCalled = false
+
+    func analyzeGoal(_ goalText: String) async throws -> StructuredGoal {
+        recordInvocation(#function, arguments: goalText)
+        analyzeGoalCalled = true
+
+        switch analyzeGoalResult {
+        case .success(let goal):
+            return goal
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    enum MockError: Error {
+        case notSet
+    }
+}
+
+extension StructuredGoal {
+    static var mock: StructuredGoal {
+        StructuredGoal(type: "weight_loss", target: 10, timeframe: 90, metric: "lb")
+    }
+}

--- a/AirFit/AirFitTests/Mocks/MockUserService.swift
+++ b/AirFit/AirFitTests/Mocks/MockUserService.swift
@@ -1,0 +1,45 @@
+@testable import AirFit
+import Foundation
+import SwiftData
+
+@MainActor
+final class MockUserService: UserServiceProtocol, MockProtocol {
+    var invocations: [String: [Any]] = [:]
+    var stubbedResults: [String: Any] = [:]
+
+    var createUserResult: Result<User, Error> = .success(User.mock)
+    var updateProfileResult: Result<Void, Error> = .success(())
+    var getCurrentUserResult: User? = User.mock
+
+    func createUser(from profile: OnboardingProfile) async throws -> User {
+        recordInvocation(#function, arguments: profile)
+        switch createUserResult {
+        case .success(let user):
+            return user
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func updateProfile(_ updates: ProfileUpdate) async throws {
+        recordInvocation(#function, arguments: updates)
+        if case .failure(let error) = updateProfileResult {
+            throw error
+        }
+    }
+
+    func getCurrentUser() -> User? {
+        recordInvocation(#function)
+        return getCurrentUserResult
+    }
+
+    func deleteUser(_ user: User) async throws {
+        recordInvocation(#function, arguments: user)
+    }
+}
+
+extension User {
+    static var mock: User {
+        User(id: UUID(), email: "test@example.com", name: "Test User", preferredUnits: "imperial")
+    }
+}

--- a/AirFit/Modules/Onboarding/Services/OnboardingServiceProtocol.swift
+++ b/AirFit/Modules/Onboarding/Services/OnboardingServiceProtocol.swift
@@ -1,0 +1,8 @@
+import Foundation
+import SwiftData
+
+/// Provides persistence for the onboarding flow.
+protocol OnboardingServiceProtocol: Sendable {
+    /// Save the completed onboarding profile.
+    func saveProfile(_ profile: OnboardingProfile) async throws
+}

--- a/AirFit/Services/AI/AIServiceProtocol.swift
+++ b/AirFit/Services/AI/AIServiceProtocol.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Interface for AI powered features used throughout the app.
+protocol AIServiceProtocol: Sendable {
+    /// Analyze a free form goal description and return a structured goal.
+    func analyzeGoal(_ goalText: String) async throws -> StructuredGoal
+}

--- a/AirFit/Services/User/UserServiceProtocol.swift
+++ b/AirFit/Services/User/UserServiceProtocol.swift
@@ -1,0 +1,17 @@
+import Foundation
+import SwiftData
+
+/// Represents changes that can be applied to a user profile.
+struct ProfileUpdate: Sendable {
+    var email: String?
+    var name: String?
+    var preferredUnits: String?
+}
+
+/// Service interface for managing `User` models.
+protocol UserServiceProtocol: AnyObject, Sendable {
+    func createUser(from profile: OnboardingProfile) async throws -> User
+    func updateProfile(_ updates: ProfileUpdate) async throws
+    func getCurrentUser() -> User?
+    func deleteUser(_ user: User) async throws
+}


### PR DESCRIPTION
## Summary
- add onboarding service protocol
- define AI service protocol used for goal analysis
- add user service protocol with profile update struct
- implement MockAIService and MockUserService for unit tests

## Testing
- `swiftlint --strict` *(fails: Loading libsourcekitdInProc.so failed)*
- `xcodebuild -scheme "AirFit" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.0' -only-testing:AirFitTests/OnboardingViewModelTests test` *(fails: command not found)*