### PR TITLE
Implement onboarding flow container

### DIFF
--- a/AirFit/Modules/Onboarding/Views/OnboardingFlowView.swift
+++ b/AirFit/Modules/Onboarding/Views/OnboardingFlowView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+import SwiftData
+import Observation
+
+struct OnboardingFlowView: View {
+    @Environment(\.modelContext) private var modelContext
+    @State private var viewModel: OnboardingViewModel
+
+    init(
+        aiService: AIServiceProtocol,
+        onboardingService: OnboardingServiceProtocol
+    ) {
+        let context = ModelContext(AirFitApp.sharedModelContainer)
+        _viewModel = State(initialValue: OnboardingViewModel(
+            aiService: aiService,
+            onboardingService: onboardingService,
+            modelContext: context
+        ))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if viewModel.currentScreen != .openingScreen &&
+                viewModel.currentScreen != .generatingCoach &&
+                viewModel.currentScreen != .coachProfileReady {
+                StepProgressBar(progress: viewModel.currentScreen.progress)
+                    .padding(.horizontal)
+                    .padding(.top)
+            }
+
+            Group {
+                switch viewModel.currentScreen {
+                case .openingScreen:
+                    OpeningScreenView(viewModel: viewModel)
+                case .lifeSnapshot:
+                    LifeSnapshotView(viewModel: viewModel)
+                case .coreAspiration:
+                    CoreAspirationView(viewModel: viewModel)
+                case .coachingStyle:
+                    CoachingStyleView(viewModel: viewModel)
+                case .engagementPreferences:
+                    EngagementPreferencesView(viewModel: viewModel)
+                case .sleepAndBoundaries:
+                    SleepAndBoundariesView(viewModel: viewModel)
+                case .motivationalAccents:
+                    MotivationalAccentsView(viewModel: viewModel)
+                case .generatingCoach:
+                    GeneratingCoachView(viewModel: viewModel)
+                case .coachProfileReady:
+                    CoachProfileReadyView(viewModel: viewModel)
+                }
+            }
+            .transition(
+                .asymmetric(
+                    insertion: .move(edge: .trailing).combined(with: .opacity),
+                    removal: .move(edge: .leading).combined(with: .opacity)
+                )
+            )
+            .animation(.easeInOut(duration: AppConstants.Animation.defaultDuration), value: viewModel.currentScreen)
+
+            if viewModel.currentScreen != .generatingCoach &&
+                viewModel.currentScreen != .coachProfileReady {
+                PrivacyFooter()
+                    .padding(.bottom)
+            }
+        }
+        .background(AppColors.backgroundPrimary)
+        .loadingOverlay(isLoading: viewModel.isLoading)
+        .alert("Error", isPresented: .constant(viewModel.error != nil)) {
+            Button("OK") { viewModel.error = nil }
+        } message: {
+            Text(viewModel.error?.localizedDescription ?? NSLocalizedString("error.generic", comment: ""))
+        }
+        .accessibilityIdentifier("onboarding.flow")
+    }
+}
+
+// MARK: - Progress Bar
+private struct StepProgressBar: View {
+    let progress: Double
+    private let segments = 7
+
+    var body: some View {
+        GeometryReader { geometry in
+            let segmentWidth = geometry.size.width / CGFloat(segments)
+            HStack(spacing: 2) {
+                ForEach(0..<segments, id: \..self) { index in
+                    Capsule()
+                        .fill(progress >= Double(index) / Double(segments - 1) ? AppColors.accentColor : AppColors.dividerColor)
+                        .frame(width: segmentWidth - 2, height: 4)
+                }
+            }
+        }
+        .frame(height: 4)
+        .accessibilityIdentifier("onboarding.progress")
+        .accessibilityValue("\(Int(progress * 100))% complete")
+    }
+}
+
+// MARK: - Privacy Footer
+private struct PrivacyFooter: View {
+    var body: some View {
+        Button(action: {
+            AppLogger.info("Privacy policy tapped", category: .onboarding)
+        }) {
+            Text("Privacy & Data")
+                .font(AppFonts.caption)
+                .foregroundColor(AppColors.textTertiary)
+        }
+        .accessibilityIdentifier("onboarding.privacy")
+    }
+}
+
+// MARK: - Placeholder Views
+private struct LifeSnapshotView: View {
+    @Bindable var viewModel: OnboardingViewModel
+    var body: some View { Text("Life Snapshot") }
+}
+
+private struct CoreAspirationView: View {
+    @Bindable var viewModel: OnboardingViewModel
+    var body: some View { Text("Core Aspiration") }
+}
+
+private struct CoachingStyleView: View {
+    @Bindable var viewModel: OnboardingViewModel
+    var body: some View { Text("Coaching Style") }
+}
+
+private struct EngagementPreferencesView: View {
+    @Bindable var viewModel: OnboardingViewModel
+    var body: some View { Text("Engagement Preferences") }
+}
+
+private struct SleepAndBoundariesView: View {
+    @Bindable var viewModel: OnboardingViewModel
+    var body: some View { Text("Sleep & Boundaries") }
+}
+
+private struct MotivationalAccentsView: View {
+    @Bindable var viewModel: OnboardingViewModel
+    var body: some View { Text("Motivational Accents") }
+}
+
+private struct GeneratingCoachView: View {
+    @Bindable var viewModel: OnboardingViewModel
+    var body: some View { Text("Generating Coach...") }
+}
+
+private struct CoachProfileReadyView: View {
+    @Bindable var viewModel: OnboardingViewModel
+    var body: some View { Text("Coach Profile Ready") }
+}
+

--- a/AirFit/Modules/Onboarding/Views/OpeningScreenView.swift
+++ b/AirFit/Modules/Onboarding/Views/OpeningScreenView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+import Observation
+
+struct OpeningScreenView: View {
+    @Bindable var viewModel: OnboardingViewModel
+    @State private var animateIn = false
+
+    var body: some View {
+        VStack(spacing: AppSpacing.large) {
+            Spacer()
+
+            VStack(spacing: AppSpacing.medium) {
+                Image(systemName: "figure.run.circle.fill")
+                    .font(.system(size: 80))
+                    .foregroundStyle(AppColors.primaryGradient)
+                    .scaleEffect(animateIn ? 1 : 0.5)
+                    .opacity(animateIn ? 1 : 0)
+
+                Text(AppConstants.appName)
+                    .font(AppFonts.largeTitle)
+                    .foregroundColor(AppColors.textPrimary)
+                    .opacity(animateIn ? 1 : 0)
+            }
+
+            VStack(spacing: AppSpacing.small) {
+                Text(LocalizedStringKey("onboarding.opening.title"))
+                    .font(AppFonts.title3)
+                    .foregroundColor(AppColors.textPrimary)
+                    .multilineTextAlignment(.center)
+
+                Text(LocalizedStringKey("onboarding.opening.subtitle"))
+                    .font(AppFonts.subheadline)
+                    .foregroundColor(AppColors.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            .opacity(animateIn ? 1 : 0)
+            .offset(y: animateIn ? 0 : 20)
+
+            Spacer()
+
+            VStack(spacing: AppSpacing.medium) {
+                Button(action: {
+                    viewModel.navigateToNextScreen()
+                }) {
+                    Text(LocalizedStringKey("onboarding.beginProfileSetup"))
+                        .font(AppFonts.bodyBold)
+                        .foregroundColor(AppColors.textOnAccent)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(AppColors.accentColor)
+                        .cornerRadius(AppConstants.Layout.defaultCornerRadius)
+                }
+                .accessibilityIdentifier("onboarding.begin.button")
+
+                Button(action: {
+                    AppLogger.info("Onboarding skipped", category: .onboarding)
+                }) {
+                    Text(LocalizedStringKey("onboarding.maybeLater"))
+                        .font(AppFonts.body)
+                        .foregroundColor(AppColors.textSecondary)
+                }
+                .accessibilityIdentifier("onboarding.skip.button")
+            }
+            .padding(.horizontal, AppSpacing.large)
+            .opacity(animateIn ? 1 : 0)
+            .offset(y: animateIn ? 0 : 20)
+        }
+        .padding(AppSpacing.medium)
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.8).delay(0.2)) {
+                animateIn = true
+            }
+        }
+    }
+}
+

--- a/AirFit/Resources/Localizable.strings
+++ b/AirFit/Resources/Localizable.strings
@@ -72,6 +72,10 @@
 
 "onboarding.complete.title" = "You're All Set!";
 "onboarding.complete.subtitle" = "Let's start your journey to better health";
+"onboarding.opening.title" = "Design Your Personalized AirFit Coach";
+"onboarding.opening.subtitle" = "A few minutes is all it takes to create a unique coaching experience tailored to you.";
+"onboarding.beginProfileSetup" = "Begin Profile Setup";
+"onboarding.maybeLater" = "Maybe Later";
 
 // MARK: - Dashboard
 "dashboard.greeting.morning" = "Good morning, %@";


### PR DESCRIPTION
## Summary
- add `OnboardingFlowView` container with 7‑segment progress bar
- implement premium `OpeningScreenView`
- localize opening screen text and CTA

## Testing
- `swiftlint --strict` *(fails: Loading libsourcekitdInProc.so failed)*
- `xcodebuild -scheme "AirFit" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.0' clean build` *(fails: command not found)*
- `xcodebuild test -scheme "AirFit" -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -only-testing:AirFitTests/OnboardingViewModelTests` *(fails: command not found)*