### PR TITLE
Implement Life and Goal onboarding views

### DIFF
--- a/AirFit/Modules/Onboarding/Views/CoreAspirationView.swift
+++ b/AirFit/Modules/Onboarding/Views/CoreAspirationView.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+import Observation
+
+// MARK: - CoreAspirationView
+struct CoreAspirationView: View {
+    @Bindable var viewModel: OnboardingViewModel
+    private let columns = [GridItem(.flexible())]
+
+    var body: some View {
+        VStack(spacing: AppSpacing.large) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: AppSpacing.large) {
+                    Text(LocalizedStringKey("onboarding.coreAspiration.prompt"))
+                        .font(AppFonts.body)
+                        .foregroundColor(AppColors.textPrimary)
+                        .padding(.horizontal, AppSpacing.large)
+                        .accessibilityIdentifier("onboarding.goal.prompt")
+
+                    LazyVGrid(columns: columns, spacing: AppSpacing.medium) {
+                        ForEach(Goal.GoalFamily.allCases, id: \..self) { family in
+                            goalCard(family: family)
+                        }
+                    }
+                    .padding(.horizontal, AppSpacing.large)
+
+                    Text(LocalizedStringKey("onboarding.coreAspiration.freeformPrompt"))
+                        .font(AppFonts.body)
+                        .foregroundColor(AppColors.textPrimary)
+                        .padding(.horizontal, AppSpacing.large)
+
+                    HStack(alignment: .center, spacing: AppSpacing.small) {
+                        TextField("", text: $viewModel.goal.rawText, axis: .vertical)
+                            .textFieldStyle(.roundedBorder)
+                            .accessibilityIdentifier("onboarding.goal.text")
+
+                        Button(action: {
+                            if viewModel.isTranscribing {
+                                viewModel.stopVoiceCapture()
+                            } else {
+                                viewModel.startVoiceCapture()
+                            }
+                        }) {
+                            Image(systemName: viewModel.isTranscribing ? "stop.circle.fill" : "mic.circle.fill")
+                                .font(.system(size: 28))
+                                .foregroundColor(AppColors.accentColor)
+                        }
+                        .accessibilityIdentifier("onboarding.goal.voice")
+                    }
+                    .padding(.horizontal, AppSpacing.large)
+                }
+            }
+
+            NavigationButtons(
+                backAction: viewModel.navigateToPreviousScreen,
+                nextAction: {
+                    Task {
+                        await viewModel.analyzeGoalText()
+                        viewModel.navigateToNextScreen()
+                    }
+                }
+            )
+        }
+        .accessibilityIdentifier("onboarding.coreAspiration")
+    }
+
+    private func goalCard(family: Goal.GoalFamily) -> some View {
+        Button(action: { viewModel.goal.family = family }) {
+            HStack {
+                Text(family.displayName)
+                    .font(AppFonts.body)
+                    .foregroundColor(AppColors.textPrimary)
+                Spacer()
+                if viewModel.goal.family == family {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(AppColors.accentColor)
+                }
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(AppColors.cardBackground)
+            .cornerRadius(AppConstants.Layout.defaultCornerRadius)
+            .overlay(
+                RoundedRectangle(cornerRadius: AppConstants.Layout.defaultCornerRadius)
+                    .stroke(viewModel.goal.family == family ? AppColors.accentColor : Color.clear, lineWidth: 2)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("onboarding.goal.\(family.rawValue)")
+    }
+}
+
+
+// MARK: - NavigationButtons
+private struct NavigationButtons: View {
+    var backAction: () -> Void
+    var nextAction: () -> Void
+
+    var body: some View {
+        HStack(spacing: AppSpacing.medium) {
+            Button(action: backAction) {
+                Text(LocalizedStringKey("action.back"))
+                    .font(AppFonts.body)
+                    .foregroundColor(AppColors.textPrimary)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(AppColors.backgroundSecondary)
+                    .cornerRadius(AppConstants.Layout.defaultCornerRadius)
+            }
+            .accessibilityIdentifier("onboarding.back.button")
+
+            Button(action: nextAction) {
+                Text(LocalizedStringKey("action.next"))
+                    .font(AppFonts.bodyBold)
+                    .foregroundColor(AppColors.textOnAccent)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(AppColors.accentColor)
+                    .cornerRadius(AppConstants.Layout.defaultCornerRadius)
+            }
+            .accessibilityIdentifier("onboarding.next.button")
+        }
+        .padding(.horizontal, AppSpacing.large)
+    }
+}
+

--- a/AirFit/Modules/Onboarding/Views/LifeSnapshotView.swift
+++ b/AirFit/Modules/Onboarding/Views/LifeSnapshotView.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+import Observation
+
+// MARK: - LifeSnapshotView
+struct LifeSnapshotView: View {
+    @Bindable var viewModel: OnboardingViewModel
+    private let columns = [GridItem(.flexible()), GridItem(.flexible())]
+
+    var body: some View {
+        VStack(spacing: AppSpacing.large) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: AppSpacing.large) {
+                    Text(LocalizedStringKey("onboarding.lifeSnapshot.prompt"))
+                        .font(AppFonts.body)
+                        .foregroundColor(AppColors.textPrimary)
+                        .padding(.horizontal, AppSpacing.large)
+                        .accessibilityIdentifier("onboarding.life.prompt")
+
+                    LazyVGrid(columns: columns, alignment: .leading, spacing: AppSpacing.medium) {
+                        checkbox(
+                            text: LocalizedStringKey("onboarding.life.deskJob"),
+                            binding: $viewModel.lifeContext.isDeskJob,
+                            id: "onboarding.life.desk_job"
+                        )
+                        checkbox(
+                            text: LocalizedStringKey("onboarding.life.activeWork"),
+                            binding: $viewModel.lifeContext.isPhysicallyActiveWork,
+                            id: "onboarding.life.active_work"
+                        )
+                        checkbox(
+                            text: LocalizedStringKey("onboarding.life.travel"),
+                            binding: $viewModel.lifeContext.travelsFrequently,
+                            id: "onboarding.life.travel"
+                        )
+                        checkbox(
+                            text: LocalizedStringKey("onboarding.life.familyCare"),
+                            binding: $viewModel.lifeContext.hasChildrenOrFamilyCare,
+                            id: "onboarding.life.family_care"
+                        )
+                        checkbox(
+                            text: LifeContext.ScheduleType.predictable.displayName,
+                            binding: Binding(
+                                get: { viewModel.lifeContext.scheduleType == .predictable },
+                                set: { if $0 { viewModel.lifeContext.scheduleType = .predictable } }
+                            ),
+                            id: "onboarding.life.schedule_predictable"
+                        )
+                        checkbox(
+                            text: LifeContext.ScheduleType.unpredictableChaotic.displayName,
+                            binding: Binding(
+                                get: { viewModel.lifeContext.scheduleType == .unpredictableChaotic },
+                                set: { if $0 { viewModel.lifeContext.scheduleType = .unpredictableChaotic } }
+                            ),
+                            id: "onboarding.life.schedule_unpredictable"
+                        )
+                    }
+                    .padding(.horizontal, AppSpacing.large)
+
+                    VStack(alignment: .leading, spacing: AppSpacing.small) {
+                        Text(LocalizedStringKey("onboarding.lifeSnapshot.workoutPrompt"))
+                            .font(AppFonts.headline)
+                            .foregroundColor(AppColors.textPrimary)
+                        ForEach(LifeContext.WorkoutWindow.allCases, id: \..self) { option in
+                            workoutOption(option)
+                        }
+                    }
+                    .padding(.horizontal, AppSpacing.large)
+                }
+            }
+
+            NavigationButtons(
+                backAction: viewModel.navigateToPreviousScreen,
+                nextAction: viewModel.navigateToNextScreen
+            )
+        }
+        .accessibilityIdentifier("onboarding.lifeSnapshot")
+    }
+
+    private func checkbox(text: LocalizedStringKey, binding: Binding<Bool>, id: String) -> some View {
+        Toggle(isOn: binding) {
+            Text(text)
+                .font(AppFonts.body)
+                .foregroundColor(AppColors.textPrimary)
+                .multilineTextAlignment(.leading)
+        }
+        .toggleStyle(CheckboxToggleStyle())
+        .accessibilityIdentifier(id)
+    }
+
+    private func workoutOption(_ option: LifeContext.WorkoutWindow) -> some View {
+        Button(action: { viewModel.lifeContext.workoutWindowPreference = option }) {
+            HStack {
+                Image(systemName: viewModel.lifeContext.workoutWindowPreference == option ? "largecircle.fill.circle" : "circle")
+                    .foregroundColor(AppColors.accentColor)
+                Text(option.displayName)
+                    .font(AppFonts.body)
+                    .foregroundColor(AppColors.textPrimary)
+                Spacer()
+            }
+            .padding(.vertical, AppSpacing.xSmall)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("onboarding.life.workout_\(option.rawValue)")
+    }
+}
+
+// MARK: - CheckboxToggleStyle
+private struct CheckboxToggleStyle: ToggleStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        Button(action: { configuration.isOn.toggle() }) {
+            HStack(alignment: .center, spacing: AppSpacing.xSmall) {
+                Image(systemName: configuration.isOn ? "checkmark.square.fill" : "square")
+                    .foregroundColor(AppColors.accentColor)
+                configuration.label
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, AppSpacing.xSmall)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - NavigationButtons
+private struct NavigationButtons: View {
+    var backAction: () -> Void
+    var nextAction: () -> Void
+
+    var body: some View {
+        HStack(spacing: AppSpacing.medium) {
+            Button(action: backAction) {
+                Text(LocalizedStringKey("action.back"))
+                    .font(AppFonts.body)
+                    .foregroundColor(AppColors.textPrimary)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(AppColors.backgroundSecondary)
+                    .cornerRadius(AppConstants.Layout.defaultCornerRadius)
+            }
+            .accessibilityIdentifier("onboarding.back.button")
+
+            Button(action: nextAction) {
+                Text(LocalizedStringKey("action.next"))
+                    .font(AppFonts.bodyBold)
+                    .foregroundColor(AppColors.textOnAccent)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(AppColors.accentColor)
+                    .cornerRadius(AppConstants.Layout.defaultCornerRadius)
+            }
+            .accessibilityIdentifier("onboarding.next.button")
+        }
+        .padding(.horizontal, AppSpacing.large)
+    }
+}
+

--- a/AirFit/Modules/Onboarding/Views/OnboardingFlowView.swift
+++ b/AirFit/Modules/Onboarding/Views/OnboardingFlowView.swift
@@ -112,15 +112,6 @@ private struct PrivacyFooter: View {
 }
 
 // MARK: - Placeholder Views
-private struct LifeSnapshotView: View {
-    @Bindable var viewModel: OnboardingViewModel
-    var body: some View { Text("Life Snapshot") }
-}
-
-private struct CoreAspirationView: View {
-    @Bindable var viewModel: OnboardingViewModel
-    var body: some View { Text("Core Aspiration") }
-}
 
 private struct CoachingStyleView: View {
     @Bindable var viewModel: OnboardingViewModel

--- a/AirFit/Resources/Localizable.strings
+++ b/AirFit/Resources/Localizable.strings
@@ -214,3 +214,12 @@
 "time.afternoon" = "Afternoon";
 "time.evening" = "Evening";
 "time.night" = "Night"; 
+// MARK: - Onboarding Flow v3
+"onboarding.lifeSnapshot.prompt" = "Understanding your daily rhythm helps your coach provide relevant support. Tap what generally applies:";
+"onboarding.life.deskJob" = "My work is primarily at a desk";
+"onboarding.life.activeWork" = "I'm often on my feet or physically active at work";
+"onboarding.life.travel" = "I travel frequently (for work or leisure)";
+"onboarding.life.familyCare" = "I have children / significant family care responsibilities";
+"onboarding.lifeSnapshot.workoutPrompt" = "My preferred time for workouts is typically:";
+"onboarding.coreAspiration.prompt" = "What is the primary aspiration you want your AirFit Coach to help you achieve?";
+"onboarding.coreAspiration.freeformPrompt" = "Briefly describe this in your own words (optional, but helpful for your coach):";


### PR DESCRIPTION
## Summary
- add checkbox-based life snapshot screen
- add card-style core aspiration screen with voice input
- localize new onboarding strings
- use new views in onboarding flow

## Testing
- `swiftlint --strict` *(fails: Loading libsourcekitdInProc.so failed)*
- `xcodebuild -scheme "AirFit" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.0' test -only-testing:AirFitTests/OnboardingViewModelTests` *(fails: command not found)*