### PR TITLE
Add onboarding coaching style and engagement screens

### DIFF
--- a/AirFit/Modules/Onboarding/Views/CoachingStyleView.swift
+++ b/AirFit/Modules/Onboarding/Views/CoachingStyleView.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+import Observation
+
+// MARK: - CoachingStyleView
+struct CoachingStyleView: View {
+    @Bindable var viewModel: OnboardingViewModel
+
+    var body: some View {
+        VStack(spacing: AppSpacing.large) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: AppSpacing.large) {
+                    Text(LocalizedStringKey("onboarding.coaching.prompt"))
+                        .font(AppFonts.body)
+                        .foregroundColor(AppColors.textPrimary)
+                        .padding(.horizontal, AppSpacing.large)
+                        .accessibilityIdentifier("onboarding.coaching.prompt")
+
+                    sliderView(
+                        title: "AUTHORITATIVE & DIRECT",
+                        value: $viewModel.blend.authoritativeDirect,
+                        description: "Provides clear, firm direction. Expects commitment.",
+                        id: "onboarding.blend.authoritative"
+                    )
+
+                    sliderView(
+                        title: "ENCOURAGING & EMPATHETIC",
+                        value: $viewModel.blend.encouragingEmpathetic,
+                        description: "Offers motivation and understanding, celebrates effort.",
+                        id: "onboarding.blend.encouraging"
+                    )
+
+                    sliderView(
+                        title: "ANALYTICAL & INSIGHTFUL",
+                        value: $viewModel.blend.analyticalInsightful,
+                        description: "Focuses on metrics, trends, and evidence-based advice.",
+                        id: "onboarding.blend.analytical"
+                    )
+
+                    sliderView(
+                        title: "PLAYFULLY PROVOCATIVE",
+                        value: $viewModel.blend.playfullyProvocative,
+                        description: "Uses light humor and challenges to motivate when appropriate.",
+                        id: "onboarding.blend.playful"
+                    )
+                }
+            }
+
+            NavigationButtons(
+                backAction: viewModel.navigateToPreviousScreen,
+                nextAction: {
+                    viewModel.validateBlend()
+                    viewModel.navigateToNextScreen()
+                }
+            )
+        }
+        .accessibilityIdentifier("onboarding.coachingStyle")
+    }
+
+    private func sliderView(
+        title: LocalizedStringKey,
+        value: Binding<Double>,
+        description: LocalizedStringKey,
+        id: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xSmall) {
+            HStack {
+                Text(title)
+                    .font(AppFonts.body)
+                    .foregroundColor(AppColors.textPrimary)
+                Spacer()
+                Text("\(Int(value.wrappedValue * 100))%")
+                    .font(AppFonts.captionBold)
+                    .foregroundColor(AppColors.textSecondary)
+            }
+
+            Slider(value: value, in: 0...1)
+                .tint(AppColors.accentColor)
+                .accessibilityIdentifier("\(id).slider")
+
+            Text(description)
+                .font(AppFonts.caption)
+                .foregroundColor(AppColors.textSecondary)
+        }
+        .padding(.horizontal, AppSpacing.large)
+    }
+}
+
+// MARK: - NavigationButtons
+private struct NavigationButtons: View {
+    var backAction: () -> Void
+    var nextAction: () -> Void
+
+    var body: some View {
+        HStack(spacing: AppSpacing.medium) {
+            Button(action: backAction) {
+                Text(LocalizedStringKey("action.back"))
+                    .font(AppFonts.body)
+                    .foregroundColor(AppColors.textPrimary)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(AppColors.backgroundSecondary)
+                    .cornerRadius(AppConstants.Layout.defaultCornerRadius)
+            }
+            .accessibilityIdentifier("onboarding.back.button")
+
+            Button(action: nextAction) {
+                Text(LocalizedStringKey("action.next"))
+                    .font(AppFonts.bodyBold)
+                    .foregroundColor(AppColors.textOnAccent)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(AppColors.accentColor)
+                    .cornerRadius(AppConstants.Layout.defaultCornerRadius)
+            }
+            .accessibilityIdentifier("onboarding.next.button")
+        }
+        .padding(.horizontal, AppSpacing.large)
+    }
+}

--- a/AirFit/Modules/Onboarding/Views/EngagementPreferencesView.swift
+++ b/AirFit/Modules/Onboarding/Views/EngagementPreferencesView.swift
@@ -1,0 +1,200 @@
+import SwiftUI
+import Observation
+
+// MARK: - EngagementPreferencesView
+struct EngagementPreferencesView: View {
+    @Bindable var viewModel: OnboardingViewModel
+
+    var body: some View {
+        VStack(spacing: AppSpacing.large) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: AppSpacing.large) {
+                    Text(LocalizedStringKey("onboarding.engagement.prompt"))
+                        .font(AppFonts.body)
+                        .foregroundColor(AppColors.textPrimary)
+                        .padding(.horizontal, AppSpacing.large)
+                        .accessibilityIdentifier("onboarding.engagement.prompt")
+
+                    VStack(spacing: AppSpacing.medium) {
+                        presetCard(
+                            title: "Data-Driven Partnership",
+                            style: .dataDrivenPartnership,
+                            id: "onboarding.engagement.dataDriven"
+                        )
+                        presetCard(
+                            title: "Balanced & Consistent",
+                            style: .balancedConsistent,
+                            id: "onboarding.engagement.balanced"
+                        )
+                        presetCard(
+                            title: "Guidance on Demand",
+                            style: .guidanceOnDemand,
+                            id: "onboarding.engagement.guidance"
+                        )
+                        presetCard(
+                            title: "Customise My Preferences",
+                            style: .custom,
+                            id: "onboarding.engagement.custom"
+                        )
+                    }
+                    .padding(.horizontal, AppSpacing.large)
+
+                    if viewModel.engagementPreferences.trackingStyle == .custom {
+                        customOptions
+                    }
+                }
+            }
+
+            NavigationButtons(
+                backAction: viewModel.navigateToPreviousScreen,
+                nextAction: {
+                    viewModel.navigateToNextScreen()
+                }
+            )
+        }
+        .accessibilityIdentifier("onboarding.engagementPreferences")
+    }
+
+    // MARK: - Preset Card
+    private func presetCard(
+        title: LocalizedStringKey,
+        style: EngagementPreferences.TrackingStyle,
+        id: String
+    ) -> some View {
+        Button(action: { selectPreset(style) }) {
+            HStack {
+                Text(title)
+                    .font(AppFonts.body)
+                    .foregroundColor(AppColors.textPrimary)
+                Spacer()
+                if viewModel.engagementPreferences.trackingStyle == style {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(AppColors.accentColor)
+                }
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(AppColors.cardBackground)
+            .cornerRadius(AppConstants.Layout.defaultCornerRadius)
+            .overlay(
+                RoundedRectangle(cornerRadius: AppConstants.Layout.defaultCornerRadius)
+                    .stroke(viewModel.engagementPreferences.trackingStyle == style ? AppColors.accentColor : Color.clear, lineWidth: 2)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(id)
+    }
+
+    // MARK: - Custom Options
+    @ViewBuilder
+    private var customOptions: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.medium) {
+            Text("Information Depth:")
+                .font(AppFonts.headline)
+                .foregroundColor(AppColors.textPrimary)
+                .padding(.top, AppSpacing.medium)
+
+            ForEach(EngagementPreferences.InformationDepth.allCases, id: \..self) { depth in
+                radioOption(
+                    title: depth.displayName,
+                    isSelected: viewModel.engagementPreferences.informationDepth == depth,
+                    action: { viewModel.engagementPreferences.informationDepth = depth },
+                    id: "onboarding.engagement.depth.\(depth.rawValue)"
+                )
+            }
+
+            Text("Proactivity & Updates:")
+                .font(AppFonts.headline)
+                .foregroundColor(AppColors.textPrimary)
+                .padding(.top, AppSpacing.medium)
+
+            ForEach(EngagementPreferences.UpdateFrequency.allCases, id: \..self) { freq in
+                radioOption(
+                    title: freq.displayName,
+                    isSelected: viewModel.engagementPreferences.updateFrequency == freq,
+                    action: { viewModel.engagementPreferences.updateFrequency = freq },
+                    id: "onboarding.engagement.frequency.\(freq.rawValue)"
+                )
+            }
+
+            Toggle(isOn: $viewModel.engagementPreferences.autoRecoveryLogicPreference) {
+                Text("Automatically suggest workout adjustments based on my recovery data")
+                    .font(AppFonts.body)
+                    .foregroundColor(AppColors.textPrimary)
+            }
+            .toggleStyle(SwitchToggleStyle(tint: AppColors.accentColor))
+            .padding(.top, AppSpacing.medium)
+            .accessibilityIdentifier("onboarding.engagement.autoRecovery")
+        }
+        .padding(.horizontal, AppSpacing.large)
+    }
+
+    private func radioOption(title: String, isSelected: Bool, action: @escaping () -> Void, id: String) -> some View {
+        Button(action: action) {
+            HStack {
+                Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                    .foregroundColor(AppColors.accentColor)
+                Text(title)
+                    .font(AppFonts.body)
+                    .foregroundColor(AppColors.textPrimary)
+                Spacer()
+            }
+            .padding(.vertical, AppSpacing.xSmall)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(id)
+    }
+
+    private func selectPreset(_ preset: EngagementPreferences.TrackingStyle) {
+        viewModel.engagementPreferences.trackingStyle = preset
+        switch preset {
+        case .dataDrivenPartnership:
+            viewModel.engagementPreferences.informationDepth = .detailed
+            viewModel.engagementPreferences.updateFrequency = .daily
+            viewModel.engagementPreferences.autoRecoveryLogicPreference = true
+        case .balancedConsistent:
+            viewModel.engagementPreferences.informationDepth = .keyMetrics
+            viewModel.engagementPreferences.updateFrequency = .weekly
+            viewModel.engagementPreferences.autoRecoveryLogicPreference = true
+        case .guidanceOnDemand:
+            viewModel.engagementPreferences.informationDepth = .essentialOnly
+            viewModel.engagementPreferences.updateFrequency = .onDemand
+            viewModel.engagementPreferences.autoRecoveryLogicPreference = false
+        case .custom:
+            break
+        }
+    }
+}
+
+// MARK: - NavigationButtons
+private struct NavigationButtons: View {
+    var backAction: () -> Void
+    var nextAction: () -> Void
+
+    var body: some View {
+        HStack(spacing: AppSpacing.medium) {
+            Button(action: backAction) {
+                Text(LocalizedStringKey("action.back"))
+                    .font(AppFonts.body)
+                    .foregroundColor(AppColors.textPrimary)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(AppColors.backgroundSecondary)
+                    .cornerRadius(AppConstants.Layout.defaultCornerRadius)
+            }
+            .accessibilityIdentifier("onboarding.back.button")
+
+            Button(action: nextAction) {
+                Text(LocalizedStringKey("action.next"))
+                    .font(AppFonts.bodyBold)
+                    .foregroundColor(AppColors.textOnAccent)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(AppColors.accentColor)
+                    .cornerRadius(AppConstants.Layout.defaultCornerRadius)
+            }
+            .accessibilityIdentifier("onboarding.next.button")
+        }
+        .padding(.horizontal, AppSpacing.large)
+    }
+}

--- a/AirFit/Modules/Onboarding/Views/OnboardingFlowView.swift
+++ b/AirFit/Modules/Onboarding/Views/OnboardingFlowView.swift
@@ -113,15 +113,6 @@ private struct PrivacyFooter: View {
 
 // MARK: - Placeholder Views
 
-private struct CoachingStyleView: View {
-    @Bindable var viewModel: OnboardingViewModel
-    var body: some View { Text("Coaching Style") }
-}
-
-private struct EngagementPreferencesView: View {
-    @Bindable var viewModel: OnboardingViewModel
-    var body: some View { Text("Engagement Preferences") }
-}
 
 private struct SleepAndBoundariesView: View {
     @Bindable var viewModel: OnboardingViewModel

--- a/AirFit/Resources/Localizable.strings
+++ b/AirFit/Resources/Localizable.strings
@@ -223,3 +223,5 @@
 "onboarding.lifeSnapshot.workoutPrompt" = "My preferred time for workouts is typically:";
 "onboarding.coreAspiration.prompt" = "What is the primary aspiration you want your AirFit Coach to help you achieve?";
 "onboarding.coreAspiration.freeformPrompt" = "Briefly describe this in your own words (optional, but helpful for your coach):";
+"onboarding.coaching.prompt" = "Define your ideal coaching interaction style. Adjust each element to create your preferred blend.";
+"onboarding.engagement.prompt" = "How deeply involved would you like your coach to be in your day-to-day tracking and planning?";


### PR DESCRIPTION
## Summary
- implement `CoachingStyleView` with interactive sliders and percentage labels
- implement `EngagementPreferencesView` with preset cards and custom options
- hook new views into `OnboardingFlowView`
- localize prompts for coaching style and engagement preferences

## Testing
- `swiftlint --strict` *(fails: Loading libsourcekitdInProc.so failed)*
- `xcodebuild -scheme "AirFit" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.0' -skipUnavailableActions build` *(fails: command not found)*