### PR TITLE
Add sleep and motivational views

### DIFF
--- a/AirFit/Modules/Onboarding/Views/MotivationalAccentsView.swift
+++ b/AirFit/Modules/Onboarding/Views/MotivationalAccentsView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+import Observation
+
+// MARK: - MotivationalAccentsView
+struct MotivationalAccentsView: View {
+    @Bindable var viewModel: OnboardingViewModel
+
+    var body: some View {
+        VStack(spacing: AppSpacing.large) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: AppSpacing.large) {
+                    Text(LocalizedStringKey("onboarding.motivation.prompt"))
+                        .font(AppFonts.body)
+                        .foregroundColor(AppColors.textPrimary)
+                        .padding(.horizontal, AppSpacing.large)
+                        .accessibilityIdentifier("onboarding.motivation.prompt")
+
+                    VStack(alignment: .leading, spacing: AppSpacing.medium) {
+                        Text(LocalizedStringKey("onboarding.motivation.celebrationPrompt"))
+                            .font(AppFonts.headline)
+                            .foregroundColor(AppColors.textPrimary)
+                        ForEach(MotivationalStyle.CelebrationStyle.allCases, id: \..self) { style in
+                            radioOption(
+                                title: style.displayName,
+                                description: style.description,
+                                isSelected: viewModel.motivationalStyle.celebrationStyle == style,
+                                action: { viewModel.motivationalStyle.celebrationStyle = style },
+                                id: "onboarding.motivation.celebration.\(style.rawValue)"
+                            )
+                        }
+                    }
+                    .padding(.horizontal, AppSpacing.large)
+
+                    VStack(alignment: .leading, spacing: AppSpacing.medium) {
+                        Text(LocalizedStringKey("onboarding.motivation.absencePrompt"))
+                            .font(AppFonts.headline)
+                            .foregroundColor(AppColors.textPrimary)
+                        ForEach(MotivationalStyle.AbsenceResponse.allCases, id: \..self) { style in
+                            radioOption(
+                                title: style.displayName,
+                                description: style.description,
+                                isSelected: viewModel.motivationalStyle.absenceResponse == style,
+                                action: { viewModel.motivationalStyle.absenceResponse = style },
+                                id: "onboarding.motivation.absence.\(style.rawValue)"
+                            )
+                        }
+                    }
+                    .padding(.horizontal, AppSpacing.large)
+                }
+            }
+
+            NavigationButtons(
+                backAction: viewModel.navigateToPreviousScreen,
+                nextAction: viewModel.navigateToNextScreen
+            )
+        }
+        .accessibilityIdentifier("onboarding.motivationalAccents")
+    }
+
+    // MARK: - Helpers
+    private func radioOption(title: String, description: String, isSelected: Bool, action: @escaping () -> Void, id: String) -> some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: AppSpacing.xSmall) {
+                HStack {
+                    Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                        .foregroundColor(AppColors.accentColor)
+                    Text(title)
+                        .font(AppFonts.body)
+                        .foregroundColor(AppColors.textPrimary)
+                    Spacer()
+                }
+                Text(description)
+                    .font(AppFonts.caption)
+                    .foregroundColor(AppColors.textSecondary)
+            }
+            .padding(.vertical, AppSpacing.xSmall)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(id)
+    }
+}
+
+// MARK: - NavigationButtons
+private struct NavigationButtons: View {
+    var backAction: () -> Void
+    var nextAction: () -> Void
+
+    var body: some View {
+        HStack(spacing: AppSpacing.medium) {
+            Button(action: backAction) {
+                Text(LocalizedStringKey("action.back"))
+                    .font(AppFonts.body)
+                    .foregroundColor(AppColors.textPrimary)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(AppColors.backgroundSecondary)
+                    .cornerRadius(AppConstants.Layout.defaultCornerRadius)
+            }
+            .accessibilityIdentifier("onboarding.back.button")
+
+            Button(action: nextAction) {
+                Text(LocalizedStringKey("action.next"))
+                    .font(AppFonts.bodyBold)
+                    .foregroundColor(AppColors.textOnAccent)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(AppColors.accentColor)
+                    .cornerRadius(AppConstants.Layout.defaultCornerRadius)
+            }
+            .accessibilityIdentifier("onboarding.next.button")
+        }
+        .padding(.horizontal, AppSpacing.large)
+    }
+}
+

--- a/AirFit/Modules/Onboarding/Views/OnboardingFlowView.swift
+++ b/AirFit/Modules/Onboarding/Views/OnboardingFlowView.swift
@@ -114,16 +114,6 @@ private struct PrivacyFooter: View {
 // MARK: - Placeholder Views
 
 
-private struct SleepAndBoundariesView: View {
-    @Bindable var viewModel: OnboardingViewModel
-    var body: some View { Text("Sleep & Boundaries") }
-}
-
-private struct MotivationalAccentsView: View {
-    @Bindable var viewModel: OnboardingViewModel
-    var body: some View { Text("Motivational Accents") }
-}
-
 private struct GeneratingCoachView: View {
     @Bindable var viewModel: OnboardingViewModel
     var body: some View { Text("Generating Coach...") }

--- a/AirFit/Modules/Onboarding/Views/SleepAndBoundariesView.swift
+++ b/AirFit/Modules/Onboarding/Views/SleepAndBoundariesView.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+import Observation
+
+// MARK: - SleepAndBoundariesView
+struct SleepAndBoundariesView: View {
+    @Bindable var viewModel: OnboardingViewModel
+
+    @State private var bedMinutes: Double
+    @State private var wakeMinutes: Double
+
+    init(viewModel: OnboardingViewModel) {
+        self.viewModel = viewModel
+        _bedMinutes = State(initialValue: Self.minutes(from: viewModel.sleepWindow.bedTime))
+        _wakeMinutes = State(initialValue: Self.minutes(from: viewModel.sleepWindow.wakeTime))
+    }
+
+    var body: some View {
+        VStack(spacing: AppSpacing.large) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: AppSpacing.large) {
+                    Text(LocalizedStringKey("onboarding.sleep.prompt"))
+                        .font(AppFonts.body)
+                        .foregroundColor(AppColors.textPrimary)
+                        .padding(.horizontal, AppSpacing.large)
+                        .accessibilityIdentifier("onboarding.sleep.prompt")
+
+                    timeSlider(
+                        title: LocalizedStringKey("onboarding.sleep.bedtime"),
+                        minutes: $bedMinutes,
+                        id: "onboarding.sleep.bedtime"
+                    )
+                    .onChange(of: bedMinutes) { newValue in
+                        viewModel.sleepWindow.bedTime = Self.hhmm(from: newValue)
+                    }
+
+                    timeSlider(
+                        title: LocalizedStringKey("onboarding.sleep.waketime"),
+                        minutes: $wakeMinutes,
+                        id: "onboarding.sleep.waketime"
+                    )
+                    .onChange(of: wakeMinutes) { newValue in
+                        viewModel.sleepWindow.wakeTime = Self.hhmm(from: newValue)
+                    }
+
+                    VStack(alignment: .leading, spacing: AppSpacing.small) {
+                        Text(LocalizedStringKey("onboarding.sleep.rhythmPrompt"))
+                            .font(AppFonts.headline)
+                            .foregroundColor(AppColors.textPrimary)
+                        ForEach(SleepWindow.SleepConsistency.allCases, id: \..self) { option in
+                            radioOption(
+                                title: option.displayName,
+                                isSelected: viewModel.sleepWindow.consistency == option,
+                                action: { viewModel.sleepWindow.consistency = option },
+                                id: "onboarding.sleep.consistency.\(option.rawValue)"
+                            )
+                        }
+                    }
+                    .padding(.horizontal, AppSpacing.large)
+
+                    Text("Timezone: \(viewModel.timezone)")
+                        .font(AppFonts.caption)
+                        .foregroundColor(AppColors.textSecondary)
+                        .padding(.horizontal, AppSpacing.large)
+                }
+            }
+
+            NavigationButtons(
+                backAction: viewModel.navigateToPreviousScreen,
+                nextAction: viewModel.navigateToNextScreen
+            )
+        }
+        .accessibilityIdentifier("onboarding.sleepBoundaries")
+    }
+
+    // MARK: - Helpers
+    private func timeSlider(title: LocalizedStringKey, minutes: Binding<Double>, id: String) -> some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xSmall) {
+            HStack {
+                Text(title)
+                    .font(AppFonts.body)
+                    .foregroundColor(AppColors.textPrimary)
+                Spacer()
+                Text(displayTime(minutes.wrappedValue))
+                    .font(AppFonts.captionBold)
+                    .foregroundColor(AppColors.textSecondary)
+            }
+
+            Slider(value: minutes, in: 0...1439, step: 15)
+                .tint(AppColors.accentColor)
+                .accessibilityIdentifier("\(id).slider")
+        }
+        .padding(.horizontal, AppSpacing.large)
+    }
+
+    private func radioOption(title: String, isSelected: Bool, action: @escaping () -> Void, id: String) -> some View {
+        Button(action: action) {
+            HStack {
+                Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                    .foregroundColor(AppColors.accentColor)
+                Text(title)
+                    .font(AppFonts.body)
+                    .foregroundColor(AppColors.textPrimary)
+                Spacer()
+            }
+            .padding(.vertical, AppSpacing.xSmall)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(id)
+    }
+
+    private func displayTime(_ minutes: Double) -> String {
+        let total = Int(minutes) % (24 * 60)
+        let hour = total / 60
+        let minute = total % 60
+        let date = Calendar.current.date(bySettingHour: hour, minute: minute, second: 0, of: Date()) ?? Date()
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    private static func minutes(from hhmm: String) -> Double {
+        let parts = hhmm.split(separator: ":")
+        guard parts.count == 2,
+              let h = Double(parts[0]),
+              let m = Double(parts[1]) else { return 0 }
+        return h * 60 + m
+    }
+
+    private static func hhmm(from minutes: Double) -> String {
+        let total = Int(minutes) % (24 * 60)
+        let h = total / 60
+        let m = total % 60
+        return String(format: "%02d:%02d", h, m)
+    }
+}
+
+// MARK: - NavigationButtons
+private struct NavigationButtons: View {
+    var backAction: () -> Void
+    var nextAction: () -> Void
+
+    var body: some View {
+        HStack(spacing: AppSpacing.medium) {
+            Button(action: backAction) {
+                Text(LocalizedStringKey("action.back"))
+                    .font(AppFonts.body)
+                    .foregroundColor(AppColors.textPrimary)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(AppColors.backgroundSecondary)
+                    .cornerRadius(AppConstants.Layout.defaultCornerRadius)
+            }
+            .accessibilityIdentifier("onboarding.back.button")
+
+            Button(action: nextAction) {
+                Text(LocalizedStringKey("action.next"))
+                    .font(AppFonts.bodyBold)
+                    .foregroundColor(AppColors.textOnAccent)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(AppColors.accentColor)
+                    .cornerRadius(AppConstants.Layout.defaultCornerRadius)
+            }
+            .accessibilityIdentifier("onboarding.next.button")
+        }
+        .padding(.horizontal, AppSpacing.large)
+    }
+}
+

--- a/AirFit/Resources/Localizable.strings
+++ b/AirFit/Resources/Localizable.strings
@@ -225,3 +225,10 @@
 "onboarding.coreAspiration.freeformPrompt" = "Briefly describe this in your own words (optional, but helpful for your coach):";
 "onboarding.coaching.prompt" = "Define your ideal coaching interaction style. Adjust each element to create your preferred blend.";
 "onboarding.engagement.prompt" = "How deeply involved would you like your coach to be in your day-to-day tracking and planning?";
+"onboarding.sleep.prompt" = "To respect your downtime, please indicate your typical sleep schedule. Your coach will avoid sending notifications during these hours.";
+"onboarding.sleep.bedtime" = "Typical Bedtime";
+"onboarding.sleep.waketime" = "Typical Wake Time";
+"onboarding.sleep.rhythmPrompt" = "My sleep rhythm is generally:";
+"onboarding.motivation.prompt" = "A couple of final touches for how your coach acknowledges your efforts and checks in.";
+"onboarding.motivation.celebrationPrompt" = "Celebrating Achievements:";
+"onboarding.motivation.absencePrompt" = "If You're Inactive for a Few Days:";


### PR DESCRIPTION
## Summary
- add SleepAndBoundariesView with HealthKit pre-fill support
- add MotivationalAccentsView
- localize new onboarding strings
- remove placeholder views from onboarding flow

## Testing
- `swiftlint --strict` *(fails: Loading libsourcekitdInProc.so failed)*
- `xcodebuild -scheme "AirFit" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.0' clean build` *(fails: command not found)*
- `xcodebuild -scheme "AirFit" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.0' test` *(fails: command not found)*