### PR TITLE
Enable HealthKit capability

### DIFF
--- a/AirFit.xcodeproj/project.pbxproj
+++ b/AirFit.xcodeproj/project.pbxproj
@@ -882,7 +882,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_STRICT_CONCURRENCY = YES;
-				INFOPLIST_FILE = AirFit/Info.plist;
+                               INFOPLIST_FILE = AirFit/Info.plist;
+                               CODE_SIGN_ENTITLEMENTS = AirFit/AirFit.entitlements;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1065,6 +1066,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_STRICT_CONCURRENCY = YES;
 				INFOPLIST_FILE = AirFit/Info.plist;
+                                CODE_SIGN_ENTITLEMENTS = AirFit/AirFit.entitlements;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/AirFit/AirFit.entitlements
+++ b/AirFit/AirFit.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.developer.healthkit</key>
+    <true/>
+    <key>com.apple.developer.healthkit.background-delivery</key>
+    <true/>
+</dict>
+</plist>

--- a/project.yml
+++ b/project.yml
@@ -112,6 +112,7 @@ targets:
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: com.airfit.app
       INFOPLIST_FILE: AirFit/Info.plist
+      CODE_SIGN_ENTITLEMENTS: AirFit/AirFit.entitlements
       SWIFT_VERSION: "6.0"
       ENABLE_STRICT_CONCURRENCY: YES
       SWIFT_STRICT_CONCURRENCY: complete


### PR DESCRIPTION
## Summary
- add HealthKit entitlements
- update project to reference entitlements

## Testing
- `swiftlint --strict` *(fails: Loading libsourcekitdInProc.so failed)*
- `xcodebuild -scheme "AirFit" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.0' clean build` *(fails: command not found)*