### PR TITLE
Implement background delivery enabling after HealthKit authorization

### DIFF
--- a/AirFit/Services/Health/HealthKitManager.swift
+++ b/AirFit/Services/Health/HealthKitManager.swift
@@ -110,6 +110,12 @@ final class HealthKitManager {
             try await healthStore.requestAuthorization(toShare: writeTypes, read: readTypes)
             authorizationStatus = .authorized
             AppLogger.info("HealthKit authorization granted", category: .health)
+
+            do {
+                try await enableBackgroundDelivery()
+            } catch {
+                AppLogger.error("Failed to enable HealthKit background delivery", error: error, category: .health)
+            }
         } catch {
             authorizationStatus = .denied
             AppLogger.error("HealthKit authorization failed", error: error, category: .health)


### PR DESCRIPTION
## Summary
- enable background delivery inside `requestAuthorization` to ensure health data updates happen automatically

## Testing
- `swiftlint --strict` *(fails: SourceKit missing)*
- `xcodebuild -scheme "AirFit" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.0' clean build` *(fails: command not found)*