### PR TITLE
Add ContextAssembler tests with HealthKit mock

### DIFF
--- a/AirFit/AirFitTests/Mocks/MockHealthKitManager.swift
+++ b/AirFit/AirFitTests/Mocks/MockHealthKitManager.swift
@@ -1,0 +1,57 @@
+@testable import AirFit
+import Foundation
+
+final class MockHealthKitManager: HealthKitManaging, @unchecked Sendable {
+    var authorizationStatus: HealthKitManager.AuthorizationStatus = .authorized
+    private(set) var refreshCalled = false
+    private(set) var requestAuthCalled = false
+
+    var activityResult: Result<ActivityMetrics, Error> = .success(ActivityMetrics())
+    var heartResult: Result<HeartHealthMetrics, Error> = .success(HeartHealthMetrics())
+    var bodyResult: Result<BodyMetrics, Error> = .success(BodyMetrics())
+    var sleepResult: Result<SleepAnalysis.SleepSession?, Error> = .success(nil)
+
+    func refreshAuthorizationStatus() {
+        refreshCalled = true
+    }
+
+    func requestAuthorization() async throws {
+        requestAuthCalled = true
+    }
+
+    func fetchTodayActivityMetrics() async throws -> ActivityMetrics {
+        switch activityResult {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func fetchHeartHealthMetrics() async throws -> HeartHealthMetrics {
+        switch heartResult {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func fetchLatestBodyMetrics() async throws -> BodyMetrics {
+        switch bodyResult {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func fetchLastNightSleep() async throws -> SleepAnalysis.SleepSession? {
+        switch sleepResult {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw error
+        }
+    }
+}

--- a/AirFit/Core/Utilities/HealthKitAuthManager.swift
+++ b/AirFit/Core/Utilities/HealthKitAuthManager.swift
@@ -4,10 +4,10 @@ import Observation
 @MainActor
 @Observable
 final class HealthKitAuthManager {
-    private let healthKitManager: HealthKitManager
+    private let healthKitManager: HealthKitManaging
     var authorizationStatus: HealthKitAuthorizationStatus = .notDetermined
 
-    init(healthKitManager: HealthKitManager = .shared) {
+    init(healthKitManager: HealthKitManaging = HealthKitManager.shared) {
         self.healthKitManager = healthKitManager
         refreshStatus()
     }

--- a/AirFit/Services/Context/ContextAssembler.swift
+++ b/AirFit/Services/Context/ContextAssembler.swift
@@ -4,10 +4,10 @@ import SwiftData
 /// Aggregates health and environmental data into `HealthContextSnapshot` instances.
 @MainActor
 final class ContextAssembler {
-    private let healthKitManager: HealthKitManager
+    private let healthKitManager: HealthKitManaging
     // Future: private let weatherService: WeatherServiceProtocol
 
-    init(healthKitManager: HealthKitManager = .shared) {
+    init(healthKitManager: HealthKitManaging = HealthKitManager.shared) {
         self.healthKitManager = healthKitManager
     }
 

--- a/AirFit/Services/Health/HealthKitManager.swift
+++ b/AirFit/Services/Health/HealthKitManager.swift
@@ -577,3 +577,5 @@ extension HeartHealthMetrics.CardioFitnessLevel {
         }
     }
 }
+
+extension HealthKitManager: HealthKitManaging {}

--- a/AirFit/Services/Health/HealthKitManagerProtocol.swift
+++ b/AirFit/Services/Health/HealthKitManagerProtocol.swift
@@ -1,0 +1,9 @@
+protocol HealthKitManaging: AnyObject {
+    var authorizationStatus: HealthKitManager.AuthorizationStatus { get }
+    func refreshAuthorizationStatus()
+    func requestAuthorization() async throws
+    func fetchTodayActivityMetrics() async throws -> ActivityMetrics
+    func fetchHeartHealthMetrics() async throws -> HeartHealthMetrics
+    func fetchLatestBodyMetrics() async throws -> BodyMetrics
+    func fetchLastNightSleep() async throws -> SleepAnalysis.SleepSession?
+}

--- a/project.yml
+++ b/project.yml
@@ -105,6 +105,7 @@ targets:
       - AirFit/Services/AI/AIServiceProtocol.swift
       - AirFit/Services/AI/AIModels.swift
       - AirFit/Services/Health/HealthKitManager.swift
+      - AirFit/Services/Health/HealthKitManagerProtocol.swift
       - AirFit/Services/Context/ContextAssembler.swift
       # Application Layer Files (CRITICAL: XcodeGen nesting bug)
       - AirFit/Application/AirFitApp.swift
@@ -140,6 +141,8 @@ targets:
       - AirFit/AirFitTests/Onboarding/OnboardingIntegrationTests.swift
       - AirFit/AirFitTests/Onboarding/OnboardingModelsTests.swift
       - AirFit/AirFitTests/Health/HealthKitManagerTests.swift
+      - AirFit/AirFitTests/Mocks/MockHealthKitManager.swift
+      - AirFit/AirFitTests/Context/ContextAssemblerTests.swift
     dependencies:
       - target: AirFit
     settings:


### PR DESCRIPTION
## Summary
- introduce `HealthKitManaging` protocol for dependency injection
- update `ContextAssembler` and `HealthKitAuthManager` to use the protocol
- conform `HealthKitManager` to the new protocol
- add mock `HealthKitManager` for testing
- create `ContextAssemblerTests` covering snapshot assembly and error handling
- update project.yml for new files

## Testing
- `swiftlint --strict` *(fails: Loading libsourcekitdInProc.so failed)*
- `xcodebuild -scheme "AirFit" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.0' test -only-testing:AirFitTests/ContextAssemblerTests` *(fails: xcodebuild: command not found)*