### PR TITLE
Implement ChatCoordinator

### DIFF
--- a/AirFit/AirFitTests/Modules/Chat/ChatCoordinatorTests.swift
+++ b/AirFit/AirFitTests/Modules/Chat/ChatCoordinatorTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import AirFit
+
+@MainActor
+final class ChatCoordinatorTests: XCTestCase {
+    var coordinator: ChatCoordinator!
+
+    override func setUp() async throws {
+        coordinator = ChatCoordinator()
+    }
+
+    func test_navigateToPushesDestination() {
+        coordinator.navigateTo(.searchResults)
+        XCTAssertEqual(coordinator.navigationPath.count, 1)
+    }
+
+    func test_showSheetSetsActiveSheet() {
+        coordinator.showSheet(.voiceSettings)
+        XCTAssertEqual(coordinator.activeSheet, .voiceSettings)
+    }
+
+    func test_scrollToStoresMessageId() {
+        coordinator.scrollTo(messageId: "123")
+        XCTAssertEqual(coordinator.scrollToMessageId, "123")
+    }
+
+    func test_dismissClearsPresentation() {
+        coordinator.showSheet(.exportChat)
+        coordinator.showPopover(.quickActions)
+        coordinator.dismiss()
+        XCTAssertNil(coordinator.activeSheet)
+        XCTAssertNil(coordinator.activePopover)
+    }
+}

--- a/AirFit/Modules/Chat/ChatCoordinator.swift
+++ b/AirFit/Modules/Chat/ChatCoordinator.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import Observation
+
+@MainActor
+@Observable
+final class ChatCoordinator {
+    // MARK: - Navigation State
+    var navigationPath = NavigationPath()
+    var activeSheet: ChatSheet?
+    var activePopover: ChatPopover?
+    var scrollToMessageId: String?
+
+    // MARK: - Sheet Types
+    enum ChatSheet: Identifiable {
+        case sessionHistory
+        case exportChat
+        case voiceSettings
+        case imageAttachment
+
+        var id: String {
+            switch self {
+            case .sessionHistory: return "history"
+            case .exportChat: return "export"
+            case .voiceSettings: return "voice"
+            case .imageAttachment: return "image"
+            }
+        }
+    }
+
+    // MARK: - Popover Types
+    enum ChatPopover: Identifiable {
+        case contextMenu(messageId: String)
+        case quickActions
+        case emojiPicker
+
+        var id: String {
+            switch self {
+            case .contextMenu(let id): return "context_\(id)"
+            case .quickActions: return "actions"
+            case .emojiPicker: return "emoji"
+            }
+        }
+    }
+
+    // MARK: - Navigation Methods
+    func navigateTo(_ destination: ChatDestination) {
+        navigationPath.append(destination)
+    }
+
+    func showSheet(_ sheet: ChatSheet) {
+        activeSheet = sheet
+    }
+
+    func showPopover(_ popover: ChatPopover) {
+        activePopover = popover
+    }
+
+    func scrollTo(messageId: String) {
+        scrollToMessageId = messageId
+    }
+
+    func dismiss() {
+        activeSheet = nil
+        activePopover = nil
+    }
+}
+
+// MARK: - Navigation Destinations
+enum ChatDestination: Hashable {
+    case messageDetail(messageId: String)
+    case searchResults
+    case sessionSettings
+}

--- a/project.yml
+++ b/project.yml
@@ -153,6 +153,7 @@ targets:
       - AirFit/Modules/Workouts/Views/WorkoutBuilderView.swift
       - AirFit/Modules/Workouts/Views/AllWorkoutsView.swift
       - AirFit/Modules/Workouts/Views/WorkoutStatisticsView.swift
+      - AirFit/Modules/Chat/ChatCoordinator.swift
       # Application Layer Files (CRITICAL: XcodeGen nesting bug)
       - AirFit/Application/AirFitApp.swift
       - AirFit/Application/MinimalContentView.swift
@@ -208,6 +209,7 @@ targets:
       - AirFit/AirFitTests/Mocks/MockCoachEngine.swift
       - AirFit/AirFitTests/Workouts/WorkoutViewModelTests.swift
       - AirFit/AirFitTests/Workouts/WorkoutCoordinatorTests.swift
+      - AirFit/AirFitTests/Modules/Chat/ChatCoordinatorTests.swift
       - AirFit/AirFitTests/Core/VoiceInputManagerTests.swift
     dependencies:
       - target: AirFit


### PR DESCRIPTION
## Summary
- add ChatCoordinator for module navigation
- provide unit tests for coordinator
- include new module file paths in project configuration

## Testing
- `swiftc AirFit/Modules/Chat/ChatCoordinator.swift -emit-sil`
