### PR TITLE
Implement ChatSuggestionsEngine

### DIFF
--- a/AirFit/AirFitTests/Modules/Chat/ChatSuggestionsEngineTests.swift
+++ b/AirFit/AirFitTests/Modules/Chat/ChatSuggestionsEngineTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import AirFit
+
+@MainActor
+final class ChatSuggestionsEngineTests: XCTestCase {
+    var user: User!
+    var engine: ChatSuggestionsEngine!
+
+    override func setUp() async throws {
+        user = User()
+        engine = ChatSuggestionsEngine(user: user)
+    }
+
+    func test_generateSuggestions_withoutHistory_returnsDefaultPrompts() async {
+        let result = await engine.generateSuggestions(messages: [], userContext: user)
+        XCTAssertGreaterThanOrEqual(result.quick.count, 4)
+    }
+
+    func test_generateSuggestions_workoutMessage_includesWorkoutSuggestion() async {
+        let message = ChatMessage(role: "user", content: "I did a hard workout", session: nil)
+        let result = await engine.generateSuggestions(messages: [message], userContext: user)
+        XCTAssertTrue(result.quick.contains { $0.text.contains("workout") })
+    }
+}

--- a/AirFit/Modules/Chat/Services/ChatSuggestionsEngine.swift
+++ b/AirFit/Modules/Chat/Services/ChatSuggestionsEngine.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+@MainActor
+final class ChatSuggestionsEngine {
+    private let user: User
+    private let contextAssembler: ContextAssembler
+
+    init(user: User, contextAssembler: ContextAssembler = ContextAssembler()) {
+        self.user = user
+        self.contextAssembler = contextAssembler
+    }
+
+    /// Generates context-aware suggestions based on recent chat messages and user context.
+    /// - Parameters:
+    ///   - messages: Recent chat messages for analysis.
+    ///   - userContext: The current user profile.
+    /// - Returns: A set of quick suggestions and contextual actions.
+    func generateSuggestions(
+        messages: [ChatMessage],
+        userContext: User
+    ) async -> SuggestionSet {
+        var quick = getFitnessPrompts()
+        var contextual: [ContextualAction] = []
+
+        // Analyze the last user message for topical hints
+        if let lastUserMessage = messages.reversed().first(where: { $0.isUserMessage }) {
+            let text = lastUserMessage.content.lowercased()
+            if text.contains("workout") {
+                quick.append(QuickSuggestion(text: "Show my workout stats", autoSend: true))
+                contextual.append(ContextualAction(title: "Log Workout", icon: "figure.run"))
+            }
+            if text.contains("nutrition") || text.contains("meal") {
+                quick.append(QuickSuggestion(text: "Log a meal", autoSend: false))
+                contextual.append(ContextualAction(title: "View Meal Plan", icon: "fork.knife"))
+            }
+            if text.contains("goal") {
+                quick.append(QuickSuggestion(text: "Review my goals", autoSend: true))
+                contextual.append(ContextualAction(title: "Update Goals", icon: "target"))
+            }
+        } else {
+            // If no conversation yet, offer starters
+            quick.append(contentsOf: [
+                QuickSuggestion(text: "What can you do?", autoSend: true),
+                QuickSuggestion(text: "Share a fitness tip", autoSend: true)
+            ])
+        }
+
+        // Incorporate simple history signals
+        if !userContext.getRecentWorkouts().isEmpty {
+            contextual.append(ContextualAction(title: "Last Workout Summary", icon: "chart.bar"))
+        }
+        if !userContext.getRecentMeals().isEmpty {
+            contextual.append(ContextualAction(title: "Recent Meals", icon: "fork.knife"))
+        }
+
+        // Remove duplicate quick suggestions by text for performance
+        var unique = Set<String>()
+        quick = quick.filter { unique.insert($0.text).inserted }
+
+        return SuggestionSet(quick: quick, contextual: contextual)
+    }
+
+    private func getFitnessPrompts() -> [QuickSuggestion] {
+        [
+            QuickSuggestion(text: "How was my workout today?", autoSend: true),
+            QuickSuggestion(text: "Plan my next workout", autoSend: false),
+            QuickSuggestion(text: "Analyze my nutrition", autoSend: true),
+            QuickSuggestion(text: "Set a new fitness goal", autoSend: false)
+        ]
+    }
+}
+
+struct SuggestionSet {
+    let quick: [QuickSuggestion]
+    let contextual: [ContextualAction]
+}

--- a/project.yml
+++ b/project.yml
@@ -154,6 +154,7 @@ targets:
       - AirFit/Modules/Workouts/Views/AllWorkoutsView.swift
       - AirFit/Modules/Workouts/Views/WorkoutStatisticsView.swift
       - AirFit/Modules/Chat/ChatCoordinator.swift
+      - AirFit/Modules/Chat/Services/ChatSuggestionsEngine.swift
       - AirFit/Modules/Chat/ViewModels/ChatViewModel.swift
       - AirFit/Modules/Chat/Views/MessageBubbleView.swift
       - AirFit/Modules/Chat/Views/MessageComposer.swift
@@ -214,6 +215,7 @@ targets:
       - AirFit/AirFitTests/Workouts/WorkoutViewModelTests.swift
       - AirFit/AirFitTests/Workouts/WorkoutCoordinatorTests.swift
       - AirFit/AirFitTests/Modules/Chat/ChatCoordinatorTests.swift
+      - AirFit/AirFitTests/Modules/Chat/ChatSuggestionsEngineTests.swift
       - AirFit/AirFitTests/Core/VoiceInputManagerTests.swift
     dependencies:
       - target: AirFit


### PR DESCRIPTION
## Summary
- add ChatSuggestionsEngine for context aware suggestions
- provide unit tests for suggestions engine
- update project.yml to include new files

## Testing
- `swiftc -parse AirFit/Modules/Chat/Services/ChatSuggestionsEngine.swift`
- `swiftc -parse AirFit/AirFitTests/Modules/Chat/ChatSuggestionsEngineTests.swift`
