### PR TITLE
Add FoodVoiceAdapter and Protocol

### DIFF
--- a/AirFit/Modules/FoodTracking/Services/FoodVoiceAdapter.swift
+++ b/AirFit/Modules/FoodTracking/Services/FoodVoiceAdapter.swift
@@ -1,0 +1,106 @@
+import Foundation
+import SwiftUI
+
+/// Adapter around `VoiceInputManager` providing food-specific enhancements.
+@MainActor
+final class FoodVoiceAdapter: ObservableObject {
+    // MARK: - Dependencies
+    private let voiceInputManager: VoiceInputManager
+
+    // MARK: - Published State
+    @Published private(set) var isRecording = false
+    @Published private(set) var transcribedText = ""
+    @Published private(set) var voiceWaveform: [Float] = []
+    @Published private(set) var isTranscribing = false
+
+    // MARK: - Callbacks
+    var onFoodTranscription: ((String) -> Void)?
+    var onError: ((Error) -> Void)?
+
+    // MARK: - Initialization
+    init(voiceInputManager: VoiceInputManager = VoiceInputManager()) {
+        self.voiceInputManager = voiceInputManager
+        setupCallbacks()
+    }
+
+    private func setupCallbacks() {
+        voiceInputManager.onTranscription = { [weak self] text in
+            guard let self else { return }
+            let processedText = self.postProcessForFood(text)
+            self.transcribedText = processedText
+            self.onFoodTranscription?(processedText)
+        }
+
+        voiceInputManager.onPartialTranscription = { [weak self] text in
+            guard let self else { return }
+            self.transcribedText = text
+        }
+
+        voiceInputManager.onWaveformUpdate = { [weak self] levels in
+            guard let self else { return }
+            self.voiceWaveform = levels
+        }
+
+        voiceInputManager.onError = { [weak self] error in
+            guard let self else { return }
+            self.onError?(error)
+        }
+    }
+
+    // MARK: - Public Methods
+    func requestPermission() async throws -> Bool {
+        try await voiceInputManager.requestPermission()
+    }
+
+    func startRecording() async throws {
+        isRecording = true
+        try await voiceInputManager.startRecording()
+    }
+
+    func stopRecording() async -> String? {
+        isRecording = false
+        let result = await voiceInputManager.stopRecording()
+        return result.map { postProcessForFood($0) }
+    }
+
+    // MARK: - Food-Specific Post-Processing
+    private func postProcessForFood(_ text: String) -> String {
+        var processed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let foodCorrections: [String: String] = [
+            // Quantity corrections
+            "to eggs": "two eggs",
+            "for slices": "four slices",
+            "won cup": "one cup",
+            "tree cups": "three cups",
+            "ate ounces": "eight ounces",
+
+            // Food name corrections
+            "chicken breast": "chicken breast",
+            "sweet potato": "sweet potato",
+            "greek yogurt": "Greek yogurt",
+            "peanut butter": "peanut butter",
+            "olive oil": "olive oil",
+
+            // Measurement corrections
+            "table spoon": "tablespoon",
+            "tea spoon": "teaspoon",
+            "fluid ounce": "fl oz",
+            "pounds": "lbs"
+        ]
+
+        for (pattern, replacement) in foodCorrections {
+            processed = processed.replacingOccurrences(
+                of: pattern,
+                with: replacement,
+                options: [.caseInsensitive]
+            )
+        }
+
+        return processed
+    }
+}
+
+// MARK: - FoodVoiceServiceProtocol Conformance
+extension FoodVoiceAdapter: FoodVoiceServiceProtocol {}
+

--- a/AirFit/Modules/FoodTracking/Services/FoodVoiceServiceProtocol.swift
+++ b/AirFit/Modules/FoodTracking/Services/FoodVoiceServiceProtocol.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Abstraction for food-specific voice operations.
+protocol FoodVoiceServiceProtocol: AnyObject {
+    /// Indicates whether recording is currently active.
+    var isRecording: Bool { get }
+    /// Indicates whether streaming transcription is active.
+    var isTranscribing: Bool { get }
+    /// Last fully transcribed text.
+    var transcribedText: String { get }
+    /// Waveform samples for UI visualization.
+    var voiceWaveform: [Float] { get }
+
+    /// Request microphone permission.
+    func requestPermission() async throws -> Bool
+    /// Start voice recording.
+    func startRecording() async throws
+    /// Stop voice recording and return processed transcription.
+    func stopRecording() async -> String?
+
+    /// Callback when a food transcription is available.
+    var onFoodTranscription: ((String) -> Void)? { get set }
+    /// Error callback.
+    var onError: ((Error) -> Void)? { get set }
+}
+
+// MARK: - FoodVoiceAdapter Protocol Conformance
+extension FoodVoiceAdapter: FoodVoiceServiceProtocol {}
+
+/// Errors that can occur in `FoodVoiceAdapter` operations.
+enum FoodVoiceError: LocalizedError {
+    case voiceInputManagerUnavailable
+    case transcriptionFailed
+    case permissionDenied
+
+    var errorDescription: String? {
+        switch self {
+        case .voiceInputManagerUnavailable:
+            return "Voice input manager from Module 13 is not available"
+        case .transcriptionFailed:
+            return "Failed to transcribe voice input"
+        case .permissionDenied:
+            return "Microphone permission was denied"
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -162,6 +162,8 @@ targets:
       - AirFit/Modules/Chat/Views/MessageComposer.swift
       - AirFit/Modules/Chat/Views/VoiceSettingsView.swift
       - AirFit/Modules/Chat/Views/ChatView.swift
+      - AirFit/Modules/FoodTracking/Services/FoodVoiceAdapter.swift
+      - AirFit/Modules/FoodTracking/Services/FoodVoiceServiceProtocol.swift
       # Application Layer Files (CRITICAL: XcodeGen nesting bug)
       - AirFit/Application/AirFitApp.swift
       - AirFit/Application/MinimalContentView.swift


### PR DESCRIPTION
## Summary
- implement `FoodVoiceAdapter` wrapping `VoiceInputManager`
- define `FoodVoiceServiceProtocol` and error enum
- include new services in `project.yml`

## Testing
- `swift -frontend -typecheck AirFit/Modules/FoodTracking/Services/FoodVoiceAdapter.swift -target arm64-apple-ios18.0 -strict-concurrency=complete` *(fails: unable to load standard library)*
- `swift -frontend -typecheck AirFit/Modules/FoodTracking/Services/FoodVoiceServiceProtocol.swift -target arm64-apple-ios18.0 -strict-concurrency=complete` *(fails: unable to load standard library)*
- `find AirFit/Modules/FoodTracking -name "*.swift" -type f`
- `grep -c "FoodVoiceAdapter.swift" project.yml`
- `grep -c "FoodVoiceServiceProtocol.swift" project.yml`
