### PR TITLE
Fix FoodTracking build error

### DIFF
--- a/AirFit/Modules/AI/CoachEngine.swift
+++ b/AirFit/Modules/AI/CoachEngine.swift
@@ -667,3 +667,29 @@ extension CoachEngine {
         }
     }
 }
+
+// MARK: - Shared Instance
+extension CoachEngine {
+    /// Shared singleton used throughout the app. This uses simple placeholder
+    /// services until full implementations are available.
+    static let shared: CoachEngine = {
+        let container = DependencyContainer.shared
+        let context = container.makeModelContext() ?? {
+            do {
+                return try ModelContainer.createTestContainer().mainContext
+            } catch {
+                fatalError("Failed to create ModelContext: \(error)")
+            }
+        }()
+
+        return CoachEngine(
+            localCommandParser: LocalCommandParser(),
+            functionDispatcher: FunctionCallDispatcher(),
+            personaEngine: PersonaEngine(),
+            conversationManager: ConversationManager(modelContext: context),
+            aiService: PlaceholderAIAPIService(),
+            contextAssembler: ContextAssembler(),
+            modelContext: context
+        )
+    }()
+}

--- a/AirFit/Services/AI/PlaceholderAIAPIService.swift
+++ b/AirFit/Services/AI/PlaceholderAIAPIService.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Combine
+
+/// Stub implementation of `AIAPIServiceProtocol` used until the real
+/// service is available.
+actor PlaceholderAIAPIService: AIAPIServiceProtocol {
+    func configure(provider: AIProvider, apiKey: String, modelIdentifier: String?) {}
+
+    func getStreamingResponse(for request: AIRequest) -> AnyPublisher<AIResponse, Error> {
+        Empty(completeImmediately: true).eraseToAnyPublisher()
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -115,6 +115,7 @@ targets:
       - AirFit/Services/AI/AIAPIServiceProtocol.swift
       - AirFit/Services/AI/AIServiceProtocol.swift
       - AirFit/Services/AI/MockAIService.swift
+      - AirFit/Services/AI/PlaceholderAIAPIService.swift
       - AirFit/Modules/AI/Parsing/LocalCommandParser.swift
       - AirFit/Modules/AI/Functions/FunctionRegistry.swift
       - AirFit/Modules/AI/Functions/WorkoutFunctions.swift


### PR DESCRIPTION
## Summary
- provide temporary `AIAPIService` stub
- wire up default singleton for `CoachEngine`
- include new service in Xcode project

## Testing
- `swift -frontend -typecheck AirFit/Modules/AI/CoachEngine.swift -target arm64-apple-ios18.0 -strict-concurrency=complete` *(fails: unable to load standard library)*
- `swift -frontend -typecheck AirFit/Services/AI/PlaceholderAIAPIService.swift -target arm64-apple-ios18.0 -strict-concurrency=complete` *(fails: unable to load standard library)*
- `grep -c "PlaceholderAIAPIService.swift" project.yml`