### PR TITLE
Fix FoodNutritionSummary initializer

### DIFF
--- a/AirFit/Modules/FoodTracking/Models/FoodTrackingModels.swift
+++ b/AirFit/Modules/FoodTracking/Models/FoodTrackingModels.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Summary of nutritional intake compared against user goals.
+struct FoodNutritionSummary: Sendable {
+    /// Total calories consumed.
+    var calories: Double = 0
+    /// Total grams of protein consumed.
+    var protein: Double = 0
+    /// Total grams of carbohydrates consumed.
+    var carbs: Double = 0
+    /// Total grams of fat consumed.
+    var fat: Double = 0
+    /// Total grams of fiber consumed.
+    var fiber: Double = 0
+    /// Total grams of sugar consumed.
+    var sugar: Double = 0
+    /// Total milligrams of sodium consumed.
+    var sodium: Double = 0
+
+    /// Daily calorie goal.
+    var calorieGoal: Double = 2000
+    /// Daily protein goal in grams.
+    var proteinGoal: Double = 150
+    /// Daily carbohydrate goal in grams.
+    var carbGoal: Double = 250
+    /// Daily fat goal in grams.
+    var fatGoal: Double = 65
+
+    /// Default initializer with zeroed values and default goals.
+    init() {}
+
+    /// Full parameter initializer for explicit summaries and goals.
+    init(
+        calories: Double,
+        protein: Double,
+        carbs: Double,
+        fat: Double,
+        fiber: Double,
+        sugar: Double,
+        sodium: Double,
+        calorieGoal: Double,
+        proteinGoal: Double,
+        carbGoal: Double,
+        fatGoal: Double
+    ) {
+        self.calories = calories
+        self.protein = protein
+        self.carbs = carbs
+        self.fat = fat
+        self.fiber = fiber
+        self.sugar = sugar
+        self.sodium = sodium
+        self.calorieGoal = calorieGoal
+        self.proteinGoal = proteinGoal
+        self.carbGoal = carbGoal
+        self.fatGoal = fatGoal
+    }
+
+    /// Progress toward the daily calorie goal as a fraction between 0 and 1.
+    var calorieProgress: Double { calories / calorieGoal }
+    /// Progress toward the daily protein goal.
+    var proteinProgress: Double { protein / proteinGoal }
+    /// Progress toward the daily carbohydrate goal.
+    var carbProgress: Double { carbs / carbGoal }
+    /// Progress toward the daily fat goal.
+    var fatProgress: Double { fat / fatGoal }
+}
+

--- a/AirFit/Modules/FoodTracking/ViewModels/FoodTrackingViewModel.swift
+++ b/AirFit/Modules/FoodTracking/ViewModels/FoodTrackingViewModel.swift
@@ -475,25 +475,6 @@ struct ParsedFoodItem: Identifiable, Sendable {
     var confidence: Float
 }
 
-struct FoodNutritionSummary: Sendable {
-    var calories: Double = 0
-    var protein: Double = 0
-    var carbs: Double = 0
-    var fat: Double = 0
-    var fiber: Double = 0
-    var sugar: Double = 0
-    var sodium: Double = 0
-
-    var calorieGoal: Double = 2000
-    var proteinGoal: Double = 50
-    var carbGoal: Double = 250
-    var fatGoal: Double = 65
-
-    var calorieProgress: Double { calories / calorieGoal }
-    var proteinProgress: Double { protein / proteinGoal }
-    var carbProgress: Double { carbs / carbGoal }
-    var fatProgress: Double { fat / fatGoal }
-}
 
 enum FoodTrackingError: LocalizedError {
     case noFoodsDetected

--- a/project.yml
+++ b/project.yml
@@ -168,6 +168,7 @@ targets:
       - AirFit/Modules/FoodTracking/Services/NutritionService.swift
       - AirFit/Modules/FoodTracking/Services/FoodDatabaseService.swift
       - AirFit/Modules/FoodTracking/Models/FoodDatabaseModels.swift
+      - AirFit/Modules/FoodTracking/Models/FoodTrackingModels.swift
       - AirFit/Modules/FoodTracking/FoodTrackingCoordinator.swift
       - AirFit/Modules/FoodTracking/ViewModels/FoodTrackingViewModel.swift
       - AirFit/Modules/FoodTracking/Views/VoiceInputView.swift


### PR DESCRIPTION
## Summary
- create `FoodTrackingModels.swift` with `FoodNutritionSummary` model
- remove inline definition of `FoodNutritionSummary` from `FoodTrackingViewModel`
- include new model file in project configuration

## Testing
- `swift -frontend -typecheck AirFit/Modules/FoodTracking/Models/FoodTrackingModels.swift -target arm64-apple-ios18.0 -strict-concurrency=complete`
- `swift -frontend -typecheck AirFit/Modules/FoodTracking/ViewModels/FoodTrackingViewModel.swift -target arm64-apple-ios18.0 -strict-concurrency=complete`
- `find AirFit/Modules/FoodTracking -name "*.swift" -type f | sort`
- `grep -c "FoodTrackingModels.swift" project.yml`