### PR TITLE
Fix VisionAnalysisResult duplication

### DIFF
--- a/AirFit/Modules/FoodTracking/Models/FoodTrackingModels.swift
+++ b/AirFit/Modules/FoodTracking/Models/FoodTrackingModels.swift
@@ -66,3 +66,11 @@ struct FoodNutritionSummary: Sendable {
     var fatProgress: Double { fat / fatGoal }
 }
 
+/// Result of analyzing a photo using Vision.
+struct VisionAnalysisResult: Sendable {
+    /// All recognized text fragments in the photo.
+    let recognizedText: [String]
+    /// Overall confidence score for the analysis.
+    let confidence: Float
+}
+


### PR DESCRIPTION
## Summary
- ensure the VisionAnalysisResult model only appears once
- keep model in `FoodTrackingModels.swift` as `Sendable`

## Testing
- `swift -frontend -typecheck AirFit/Modules/FoodTracking/Models/FoodTrackingModels.swift -target arm64-apple-ios18.0 -strict-concurrency=complete` *(fails: unable to load standard library)*
- `find AirFit/Modules/FoodTracking -name "*.swift" -type f`
- `grep -n "FoodTrackingModels.swift" project.yml`