### PR TITLE
Add supporting types and timeout error

### DIFF
--- a/AirFit/Modules/FoodTracking/Models/FoodTrackingModels.swift
+++ b/AirFit/Modules/FoodTracking/Models/FoodTrackingModels.swift
@@ -117,3 +117,26 @@ struct ParsedFoodItem: Identifiable, Sendable {
     var sodium: Double? { sodiumMilligrams }
 }
 
+/// Indicates that an asynchronous operation exceeded the allowed duration.
+struct TimeoutError: Error, LocalizedError, Sendable {
+    /// The name of the operation that timed out.
+    let operation: String
+    /// The duration after which the timeout occurred.
+    let timeoutDuration: TimeInterval
+
+    /// Human readable description for display and logging.
+    var errorDescription: String? {
+        "Operation '\(operation)' timed out after \(timeoutDuration) seconds"
+    }
+}
+
+/// Result of analyzing a meal photo using Vision and AI models.
+struct MealPhotoAnalysisResult: Sendable {
+    /// The food items that were detected in the photo.
+    let items: [ParsedFoodItem]
+    /// Overall confidence score for the photo analysis.
+    let confidence: Float
+    /// The amount of time the analysis took to complete.
+    let processingTime: TimeInterval
+}
+


### PR DESCRIPTION
## Summary
- add missing TimeoutError struct
- add MealPhotoAnalysisResult model for photo analysis results

## Testing
- `swift -frontend -typecheck AirFit/Modules/FoodTracking/Models/FoodTrackingModels.swift -target arm64-apple-ios18.0 -strict-concurrency=complete`
- `find AirFit/Modules/FoodTracking -name "*.swift" -type f`
- `grep -c "FoodTrackingModels.swift" project.yml`
