### PR TITLE
Implement expanded NutritionService protocol

### DIFF
--- a/AirFit/Modules/FoodTracking/Services/FoodVoiceServiceProtocol.swift
+++ b/AirFit/Modules/FoodTracking/Services/FoodVoiceServiceProtocol.swift
@@ -44,33 +44,6 @@ enum FoodVoiceError: LocalizedError {
     }
 }
 
-// MARK: - Nutrition Service Protocol
-protocol NutritionServiceProtocol: Sendable {
-    /// Retrieves all `FoodEntry` objects for the specified date.
-    func getFoodEntries(for user: User, date: Date) async throws -> [FoodEntry]
-
-    /// Calculates a nutrition summary from a set of entries.
-    nonisolated func calculateNutritionSummary(from entries: [FoodEntry]) -> FoodNutritionSummary
-
-    /// Returns the amount of water consumed on a given day in milliliters.
-    func getWaterIntake(for user: User, date: Date) async throws -> Double
-
-    /// Retrieves the most recent foods logged by the user.
-    func getRecentFoods(for user: User, limit: Int) async throws -> [FoodItem]
-
-    /// Logs water intake for a user at the specified date.
-    func logWaterIntake(for user: User, amountML: Double, date: Date) async throws
-
-    /// Returns the meal history for a particular meal type.
-    func getMealHistory(for user: User, mealType: MealType, daysBack: Int) async throws -> [FoodEntry]
-
-    /// Nutrition targets derived from the onboarding profile.
-    func getTargets(from profile: OnboardingProfile?) -> NutritionTargets
-
-    /// Convenience helper to generate today's summary.
-    func getTodaysSummary(for user: User) async throws -> FoodNutritionSummary
-}
-
 // MARK: - Food Database Service Protocol
 protocol FoodDatabaseServiceProtocol: Sendable {
     func searchCommonFood(_ name: String) async throws -> FoodDatabaseItem?

--- a/AirFit/Modules/FoodTracking/Services/NutritionService.swift
+++ b/AirFit/Modules/FoodTracking/Services/NutritionService.swift
@@ -10,6 +10,34 @@ actor NutritionService: NutritionServiceProtocol {
     init(modelContext: ModelContext) {
         self.modelContext = modelContext
     }
+
+    // MARK: - Basic CRUD
+
+    func saveFoodEntry(_ entry: FoodEntry) async throws {
+        modelContext.insert(entry)
+        try modelContext.save()
+    }
+
+    func getFoodEntries(for date: Date) async throws -> [FoodEntry] {
+        let calendar = Calendar.current
+        let startOfDay = calendar.startOfDay(for: date)
+        let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) ?? date
+
+        let descriptor = FetchDescriptor<FoodEntry>(
+            predicate: #Predicate<FoodEntry> { entry in
+                entry.loggedAt >= startOfDay &&
+                entry.loggedAt < endOfDay
+            },
+            sortBy: [SortDescriptor(\.loggedAt)]
+        )
+
+        return try modelContext.fetch(descriptor)
+    }
+
+    func deleteFoodEntry(_ entry: FoodEntry) async throws {
+        modelContext.delete(entry)
+        try modelContext.save()
+    }
     
     func getFoodEntries(for user: User, date: Date) async throws -> [FoodEntry] {
         let calendar = Calendar.current

--- a/AirFit/Modules/FoodTracking/Services/NutritionServiceProtocol.swift
+++ b/AirFit/Modules/FoodTracking/Services/NutritionServiceProtocol.swift
@@ -1,0 +1,38 @@
+import Foundation
+import SwiftData
+
+/// Abstraction for nutrition-related data operations and calculations.
+protocol NutritionServiceProtocol: Sendable {
+    /// Persist a new `FoodEntry` to the data store.
+    func saveFoodEntry(_ entry: FoodEntry) async throws
+
+    /// Retrieve all food entries for the given date.
+    func getFoodEntries(for date: Date) async throws -> [FoodEntry]
+
+    /// Remove the specified `FoodEntry` from the data store.
+    func deleteFoodEntry(_ entry: FoodEntry) async throws
+
+    /// Retrieves all `FoodEntry` objects for the specified user and date.
+    func getFoodEntries(for user: User, date: Date) async throws -> [FoodEntry]
+
+    /// Calculates a nutrition summary from a collection of entries.
+    nonisolated func calculateNutritionSummary(from entries: [FoodEntry]) -> FoodNutritionSummary
+
+    /// Returns the amount of water consumed on a given day in milliliters.
+    func getWaterIntake(for user: User, date: Date) async throws -> Double
+
+    /// Retrieves the most recent foods logged by the user.
+    func getRecentFoods(for user: User, limit: Int) async throws -> [FoodItem]
+
+    /// Logs water intake for a user at the specified date.
+    func logWaterIntake(for user: User, amountML: Double, date: Date) async throws
+
+    /// Returns the meal history for a particular meal type and time span.
+    func getMealHistory(for user: User, mealType: MealType, daysBack: Int) async throws -> [FoodEntry]
+
+    /// Nutrition targets derived from the onboarding profile.
+    nonisolated func getTargets(from profile: OnboardingProfile?) -> NutritionTargets
+
+    /// Convenience helper to generate today's nutrition summary.
+    func getTodaysSummary(for user: User) async throws -> FoodNutritionSummary
+}

--- a/project.yml
+++ b/project.yml
@@ -165,6 +165,7 @@ targets:
       - AirFit/Modules/Chat/Views/ChatView.swift
       - AirFit/Modules/FoodTracking/Services/FoodVoiceAdapter.swift
       - AirFit/Modules/FoodTracking/Services/FoodVoiceServiceProtocol.swift
+      - AirFit/Modules/FoodTracking/Services/NutritionServiceProtocol.swift
       - AirFit/Modules/FoodTracking/Services/NutritionService.swift
       - AirFit/Modules/FoodTracking/Services/FoodDatabaseService.swift
       - AirFit/Modules/FoodTracking/Models/FoodDatabaseModels.swift


### PR DESCRIPTION
## Summary
- add a dedicated `NutritionServiceProtocol` with full API surface
- implement CRUD helpers in `NutritionService`
- clean up `FoodVoiceServiceProtocol` by removing unrelated protocol
- register new file in project configuration

## Testing
- `swift -frontend -typecheck AirFit/Modules/FoodTracking/Services/NutritionService.swift -target arm64-apple-ios18.0 -strict-concurrency=complete` *(fails: unable to load standard library)*
- `swift -frontend -typecheck AirFit/Modules/FoodTracking/Services/NutritionServiceProtocol.swift -target arm64-apple-ios18.0 -strict-concurrency=complete` *(fails: unable to load standard library)*
- `swift -frontend -typecheck AirFit/Modules/FoodTracking/Services/FoodVoiceServiceProtocol.swift -target arm64-apple-ios18.0 -strict-concurrency=complete` *(fails: unable to load standard library)*
- `find AirFit/Modules/FoodTracking -name "*.swift" -type f`
- `grep -c "NutritionServiceProtocol.swift" project.yml`