### PR TITLE
Implement FoodCoachEngine protocol and CoachEngine extension

### DIFF
--- a/AirFit/Modules/AI/CoachEngine.swift
+++ b/AirFit/Modules/AI/CoachEngine.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftData
 import Observation
 import Combine
+import UIKit
 
 // MARK: - CoachEngine
 @MainActor
@@ -694,5 +695,33 @@ extension CoachEngine {
             contextAssembler: ContextAssembler(),
             modelContext: modelContext
         )
+    }
+}
+
+// MARK: - FoodCoachEngineProtocol Conformance
+extension CoachEngine: FoodCoachEngineProtocol {
+    func processUserMessage(_ message: String, context: HealthContextSnapshot?) async throws -> [String: SendableValue] {
+        // Placeholder implementation leveraging existing pipeline.
+        await processUserMessage(message, for: User())
+        return ["response": .string(currentResponse)]
+    }
+
+    func executeFunction(_ functionCall: AIFunctionCall, for user: User) async throws -> FunctionExecutionResult {
+        return try await functionDispatcher.execute(
+            functionCall,
+            for: user,
+            context: FunctionContext(
+                modelContext: modelContext,
+                conversationId: activeConversationId ?? UUID(),
+                userId: user.id
+            )
+        )
+    }
+
+    func analyzeMealPhoto(image: UIImage, context: NutritionContext?) async throws -> MealPhotoAnalysisResult {
+        let startTime = CFAbsoluteTimeGetCurrent()
+        // Placeholder - full vision and AI analysis to be implemented in future tasks
+        let processingTime = CFAbsoluteTimeGetCurrent() - startTime
+        return MealPhotoAnalysisResult(items: [], confidence: 0, processingTime: processingTime)
     }
 }

--- a/AirFit/Modules/FoodTracking/ViewModels/FoodTrackingViewModel.swift
+++ b/AirFit/Modules/FoodTracking/ViewModels/FoodTrackingViewModel.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 import SwiftData
 import Observation
+import Foundation
+import UIKit
 
 /// Central business logic coordinator for food tracking.
 @MainActor
@@ -487,5 +489,19 @@ enum WaterUnit: String, CaseIterable {
         case .liters: return amount * 1000
         }
     }
+}
+
+// MARK: - Protocols
+
+/// Interface for AI-powered nutrition coaching features.
+protocol FoodCoachEngineProtocol: Sendable {
+    /// Processes a free-form user message related to nutrition.
+    func processUserMessage(_ message: String, context: HealthContextSnapshot?) async throws -> [String: SendableValue]
+
+    /// Executes a high-value function call on behalf of the user.
+    func executeFunction(_ functionCall: AIFunctionCall, for user: User) async throws -> FunctionExecutionResult
+
+    /// Analyzes a meal photo and returns detected foods and nutrition data.
+    func analyzeMealPhoto(image: UIImage, context: NutritionContext?) async throws -> MealPhotoAnalysisResult
 }
 


### PR DESCRIPTION
## Summary
- add missing UIKit/Foundation imports in `FoodTrackingViewModel`
- define `FoodCoachEngineProtocol` with required methods
- import UIKit in `CoachEngine`
- implement placeholder conformance to `FoodCoachEngineProtocol`

## Testing
- `swift -frontend -typecheck AirFit/Modules/FoodTracking/ViewModels/FoodTrackingViewModel.swift -target arm64-apple-ios18.0 -strict-concurrency=complete` *(fails: unable to load standard library)*
- `swift -frontend -typecheck AirFit/Modules/AI/CoachEngine.swift -target arm64-apple-ios18.0 -strict-concurrency=complete` *(fails: unable to load standard library)*
- `find AirFit/Modules/FoodTracking -name "*.swift" -type f | head`
- `grep -c "FoodTrackingViewModel.swift" project.yml`
- `grep -c "CoachEngine.swift" project.yml`
