### PR TITLE
Fix test container user initialization

### DIFF
--- a/AirFit/Data/Extensions/ModelContainer+Testing.swift
+++ b/AirFit/Data/Extensions/ModelContainer+Testing.swift
@@ -46,6 +46,9 @@ extension ModelContainer {
 
         // Create test user
         let user = User(
+            id: UUID(),
+            createdAt: Date(),
+            lastActiveAt: Date(),
             email: "test@example.com",
             name: "Test User",
             preferredUnits: "metric"


### PR DESCRIPTION
## Summary
- update test container user initialization to explicitly include all parameters
- verify FoodTrackingViewModel uses default initializers for new model types

## Testing
- `swift -frontend -typecheck AirFit/Modules/FoodTracking/ViewModels/FoodTrackingViewModel.swift -target arm64-apple-ios18.0 -strict-concurrency=complete` *(fails: unable to load standard library)*
- `swift -frontend -typecheck AirFit/Data/Extensions/ModelContainer+Testing.swift -target arm64-apple-ios18.0 -strict-concurrency=complete` *(fails: unable to load standard library)*
- `find AirFit/Modules/FoodTracking -name "*.swift" -type f`
- `grep -n "FoodTrackingViewModel.swift" project.yml`
- `grep -n "ModelContainer+Testing.swift" project.yml`