### PR TITLE
Fix FoodTrackingError enum definition

### DIFF
--- a/AirFit/Modules/FoodTracking/Models/FoodTrackingModels.swift
+++ b/AirFit/Modules/FoodTracking/Models/FoodTrackingModels.swift
@@ -140,3 +140,40 @@ struct MealPhotoAnalysisResult: Sendable {
     let processingTime: TimeInterval
 }
 
+/// Errors that can occur when tracking foods or processing nutrition data.
+enum FoodTrackingError: Error, LocalizedError, Sendable {
+    /// Persistence layer failed to save the logged items.
+    case saveFailed
+    /// Network connectivity prevented the requested operation.
+    case networkError
+    /// Voice recognition failed to produce a valid transcript.
+    case voiceRecognitionFailed
+    /// AI parsing failed with a suggestion for the user.
+    case aiProcessingFailed(suggestion: String)
+    /// AI processing exceeded the allotted time.
+    case aiProcessingTimeout
+    /// No food items were detected from the provided input.
+    case noFoodsDetected
+    /// Photo analysis could not determine any usable results.
+    case photoAnalysisFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .saveFailed:
+            return "Failed to save food entry"
+        case .networkError:
+            return "Network connection error"
+        case .voiceRecognitionFailed:
+            return "Voice recognition failed"
+        case let .aiProcessingFailed(suggestion):
+            return "AI processing failed. \(suggestion)"
+        case .aiProcessingTimeout:
+            return "AI processing timed out"
+        case .noFoodsDetected:
+            return "No food items detected"
+        case .photoAnalysisFailed:
+            return "Photo analysis failed"
+        }
+    }
+}
+

--- a/AirFit/Modules/FoodTracking/ViewModels/FoodTrackingViewModel.swift
+++ b/AirFit/Modules/FoodTracking/ViewModels/FoodTrackingViewModel.swift
@@ -458,22 +458,6 @@ final class FoodTrackingViewModel {
     }
 }
 
-enum FoodTrackingError: LocalizedError {
-    case noFoodsDetected
-    case barcodeNotFound
-    case saveFailed
-
-    var errorDescription: String? {
-        switch self {
-        case .noFoodsDetected:
-            return "No foods detected in your description"
-        case .barcodeNotFound:
-            return "Product not found in database"
-        case .saveFailed:
-            return "Failed to save food entry"
-        }
-    }
-}
 
 enum WaterUnit: String, CaseIterable {
     case ml = "ml"


### PR DESCRIPTION
## Summary
- move `FoodTrackingError` into models with more cases
- remove old enum from the view model

## Testing
- `swift -frontend -typecheck AirFit/Modules/FoodTracking/Models/FoodTrackingModels.swift -target arm64-apple-ios18.0 -strict-concurrency=complete`
- `swift -frontend -typecheck AirFit/Modules/FoodTracking/ViewModels/FoodTrackingViewModel.swift -target arm64-apple-ios18.0 -strict-concurrency=complete`
- `find AirFit/Modules/FoodTracking -name "*.swift" -type f | sort | head`
- `grep -c "FoodTrackingModels.swift" project.yml`
- `grep -c "FoodTrackingViewModel.swift" project.yml`
