### PR TITLE
Add Sendable conformance across codebase

### DIFF
--- a/AirFit/Core/Models/WorkoutBuilderData.swift
+++ b/AirFit/Core/Models/WorkoutBuilderData.swift
@@ -2,7 +2,7 @@ import Foundation
 import HealthKit
 
 // MARK: - Shared Workout Builder Types
-struct WorkoutBuilderData: Codable {
+struct WorkoutBuilderData: Codable, Sendable {
     var id = UUID()
     var workoutType: Int = 0
     var startTime: Date?
@@ -13,7 +13,7 @@ struct WorkoutBuilderData: Codable {
     var duration: TimeInterval = 0
 }
 
-struct ExerciseBuilderData: Codable {
+struct ExerciseBuilderData: Codable, Sendable {
     let id: UUID
     let name: String
     let muscleGroups: [String]
@@ -21,7 +21,7 @@ struct ExerciseBuilderData: Codable {
     var sets: [SetBuilderData] = []
 }
 
-struct SetBuilderData: Codable {
+struct SetBuilderData: Codable, Sendable {
     let reps: Int?
     let weightKg: Double?
     let duration: TimeInterval?
@@ -29,7 +29,7 @@ struct SetBuilderData: Codable {
     let completedAt: Date
 }
 
-enum WorkoutError: LocalizedError {
+enum WorkoutError: LocalizedError, Sendable {
     case saveFailed
     case syncFailed
 

--- a/AirFit/Core/Protocols/ViewModelProtocol.swift
+++ b/AirFit/Core/Protocols/ViewModelProtocol.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 /// Base protocol for all ViewModels in the app
 @MainActor
-protocol ViewModelProtocol: AnyObject, Observable {
+protocol ViewModelProtocol: AnyObject, Observable, Sendable {
     /// The current loading state of the view model
     var loadingState: LoadingState { get }
 
@@ -31,7 +31,7 @@ extension ViewModelProtocol {
 
 /// Protocol for ViewModels that handle form validation
 @MainActor
-protocol FormViewModelProtocol: ViewModelProtocol {
+protocol FormViewModelProtocol: ViewModelProtocol, Sendable {
     associatedtype FormData
 
     /// The current form data
@@ -49,7 +49,7 @@ protocol FormViewModelProtocol: ViewModelProtocol {
 
 /// Protocol for ViewModels that handle list data
 @MainActor
-protocol ListViewModelProtocol: ViewModelProtocol {
+protocol ListViewModelProtocol: ViewModelProtocol, Sendable {
     associatedtype Item: Identifiable
 
     /// The list items
@@ -70,7 +70,7 @@ protocol ListViewModelProtocol: ViewModelProtocol {
 
 /// Protocol for ViewModels that handle detail views
 @MainActor
-protocol DetailViewModelProtocol: ViewModelProtocol {
+protocol DetailViewModelProtocol: ViewModelProtocol, Sendable {
     associatedtype Model
 
     /// The detail model

--- a/AirFit/Core/Services/WhisperModelManager.swift
+++ b/AirFit/Core/Services/WhisperModelManager.swift
@@ -7,7 +7,7 @@ final class WhisperModelManager: ObservableObject {
     static let shared = WhisperModelManager()
 
     // MARK: - Model Configuration
-    struct WhisperModel: Identifiable {
+    struct WhisperModel: Identifiable, Sendable {
         let id: String
         let displayName: String
         let size: String
@@ -19,7 +19,7 @@ final class WhisperModelManager: ObservableObject {
         let huggingFaceRepo: String
     }
 
-    enum ModelError: LocalizedError {
+    enum ModelError: LocalizedError, Sendable {
         case modelNotFound
         case insufficientStorage
         case downloadFailed(String)

--- a/AirFit/Core/Theme/AppColors.swift
+++ b/AirFit/Core/Theme/AppColors.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public struct AppColors {
+public struct AppColors: Sendable {
     // MARK: - Background Colors
     static let backgroundPrimary = Color("BackgroundPrimary")
     static let backgroundSecondary = Color("BackgroundSecondary")

--- a/AirFit/Core/Theme/AppFonts.swift
+++ b/AirFit/Core/Theme/AppFonts.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
-public struct AppFonts {
+public struct AppFonts: Sendable {
     // MARK: - Font Sizes
-    private enum Size {
+    private enum Size: Sendable {
         static let largeTitle: CGFloat = 34
         static let title: CGFloat = 28
         static let title2: CGFloat = 22

--- a/AirFit/Core/Theme/AppShadows.swift
+++ b/AirFit/Core/Theme/AppShadows.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public struct AppShadows {
+public struct AppShadows: Sendable {
     // MARK: - Shadow Styles
     static let small = Shadow(
         color: Color.black.opacity(0.08),
@@ -61,7 +61,7 @@ public struct AppShadows {
 }
 
 // MARK: - Shadow Model
-struct Shadow {
+struct Shadow: Sendable {
     let color: Color
     let radius: CGFloat
     let x: CGFloat

--- a/AirFit/Core/Theme/AppSpacing.swift
+++ b/AirFit/Core/Theme/AppSpacing.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public enum AppSpacing {
+public enum AppSpacing: Sendable {
     /// 4pt
     static let xxSmall: CGFloat = 4
     /// 8pt

--- a/AirFit/Core/Utilities/AppLogger.swift
+++ b/AirFit/Core/Utilities/AppLogger.swift
@@ -65,7 +65,7 @@ public enum AppLogger {
         )
     }
 
-    struct LogContext {
+    struct LogContext: Sendable {
         let file: String
         let function: String
         let line: Int

--- a/AirFit/Core/Utilities/DependencyContainer.swift
+++ b/AirFit/Core/Utilities/DependencyContainer.swift
@@ -43,7 +43,7 @@ public final class DependencyContainer: @unchecked Sendable {
 // MARK: - Environment Values
 import SwiftUI
 
-private struct DependencyContainerKey: EnvironmentKey {
+private struct DependencyContainerKey: EnvironmentKey, Sendable {
     static let defaultValue = DependencyContainer.shared
 }
 

--- a/AirFit/Modules/AI/Functions/FunctionCallDispatcher.swift
+++ b/AirFit/Modules/AI/Functions/FunctionCallDispatcher.swift
@@ -133,14 +133,14 @@ protocol EducationServiceProtocol: Sendable {
 
 // MARK: - Result Types
 
-struct WorkoutPlanResult {
+struct WorkoutPlanResult: Sendable {
     let id: UUID
     let exercises: [ExerciseInfo]
     let estimatedCalories: Int
     let estimatedDuration: Int
     let summary: String
 
-    struct ExerciseInfo {
+    struct ExerciseInfo: Sendable {
         let name: String
         let sets: Int
         let reps: String
@@ -149,7 +149,7 @@ struct WorkoutPlanResult {
     }
 }
 
-struct NutritionLogResult {
+struct NutritionLogResult: Sendable {
     let id: UUID
     let items: [FoodItemInfo]
     let totalCalories: Double
@@ -159,7 +159,7 @@ struct NutritionLogResult {
     let confidence: Double
     let alternatives: [String]?
 
-    struct FoodItemInfo {
+    struct FoodItemInfo: Sendable {
         let name: String
         let quantity: String
         let calories: Double
@@ -169,14 +169,14 @@ struct NutritionLogResult {
     }
 }
 
-struct PerformanceAnalysisResult {
+struct PerformanceAnalysisResult: Sendable {
     let summary: String
     let insights: [String]
     let trends: [TrendInfo]
     let recommendations: [String]
     let dataPoints: Int
 
-    struct TrendInfo {
+    struct TrendInfo: Sendable {
         let metric: String
         let direction: String
         let magnitude: Double
@@ -184,7 +184,7 @@ struct PerformanceAnalysisResult {
     }
 }
 
-struct GoalResult {
+struct GoalResult: Sendable {
     let id: UUID
     let title: String
     let description: String
@@ -193,7 +193,7 @@ struct GoalResult {
     let milestones: [String]
     let smartCriteria: SMARTCriteria
 
-    struct SMARTCriteria {
+    struct SMARTCriteria: Sendable {
         let specific: String
         let measurable: String
         let achievable: String
@@ -202,7 +202,7 @@ struct GoalResult {
     }
 }
 
-struct EducationalContentResult {
+struct EducationalContentResult: Sendable {
     let topic: String
     let content: String
     let keyPoints: [String]
@@ -237,7 +237,7 @@ final class FunctionCallDispatcher: @unchecked Sendable {
     // Function name lookup table for O(1) dispatch
     private let functionDispatchTable: [String: @Sendable (FunctionCallDispatcher, [String: AIAnyCodable], User, FunctionContext) async throws -> (message: String, data: [String: Any])]
 
-    private struct FunctionMetrics {
+    private struct FunctionMetrics: Sendable {
         var totalCalls: Int = 0
         var totalExecutionTime: TimeInterval = 0
         var successCount: Int = 0

--- a/AirFit/Modules/AI/WorkoutAnalysisEngine.swift
+++ b/AirFit/Modules/AI/WorkoutAnalysisEngine.swift
@@ -104,7 +104,7 @@ final class WorkoutAnalysisEngine {
 }
 
 // MARK: - Supporting Types
-struct PostWorkoutAnalysisRequest {
+struct PostWorkoutAnalysisRequest: Sendable {
     let workout: Workout
     let recentWorkouts: [Workout]
     let userGoals: [String]?
@@ -118,7 +118,7 @@ struct PostWorkoutAnalysisRequest {
     }
 }
 
-struct RecoveryData {
+struct RecoveryData: Sendable {
     let sleepHours: Double?
     let restingHeartRate: Int?
     let hrv: Double?

--- a/AirFit/Modules/Chat/ViewModels/ChatViewModel.swift
+++ b/AirFit/Modules/Chat/ViewModels/ChatViewModel.swift
@@ -337,7 +337,7 @@ struct ContextualAction: Identifiable, Sendable {
     let icon: String?
 }
 
-enum ChatError: LocalizedError, Equatable {
+enum ChatError: LocalizedError, Equatable, Sendable {
     case noActiveSession
     case exportFailed(String)
     case voiceRecognitionUnavailable

--- a/AirFit/Modules/Workouts/ViewModels/WorkoutViewModel.swift
+++ b/AirFit/Modules/Workouts/ViewModels/WorkoutViewModel.swift
@@ -150,7 +150,7 @@ protocol CoachEngineProtocol: AnyObject, Sendable {
 extension CoachEngine: CoachEngineProtocol {}
 
 // MARK: - Supporting Types
-struct WeeklyWorkoutStats {
+struct WeeklyWorkoutStats: Sendable {
     var totalWorkouts: Int = 0
     var totalDuration: TimeInterval = 0
     var totalCalories: Double = 0


### PR DESCRIPTION
## Summary
- mark all ViewModel protocols as `Sendable`
- ensure app themes and utility structs are `Sendable`
- conform workout and AI result models to `Sendable`
- update chat error enum for concurrency safety
- add sendable to workout-related models and supporting types

## Testing
- `swiftc -typecheck AirFit/Core/Protocols/ViewModelProtocol.swift -target arm64-apple-ios18.0 -strict-concurrency=complete`
- `swiftc -typecheck AirFit/Core/Services/WhisperModelManager.swift -target arm64-apple-ios18.0 -strict-concurrency=complete`
- `swiftc -typecheck AirFit/Modules/AI/Functions/FunctionCallDispatcher.swift -target arm64-apple-ios18.0 -strict-concurrency=complete`
- `swiftc -typecheck AirFit/Modules/Chat/ViewModels/ChatViewModel.swift -target arm64-apple-ios18.0 -strict-concurrency=complete`
